### PR TITLE
add settings in context processors

### DIFF
--- a/ecommerce/core/context_processors.py
+++ b/ecommerce/core/context_processors.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from ecommerce.core.url_utils import get_lms_dashboard_url, get_lms_url
 
 
@@ -9,6 +11,7 @@ def core(request):
         'lms_base_url': get_lms_url(),
         'lms_dashboard_url': get_lms_dashboard_url(),
         'platform_name': site.name,
+        'settings': settings,
         'support_url': site_configuration.payment_support_url,
         'optimizely_snippet_src': site_configuration.optimizely_snippet_src,
     }


### PR DESCRIPTION
Add `settings` in context processors so that it is available in the templates.

The reason is that we want to display the marketing urls in footer form ecommerce configuration/settings.

<img width="1389" alt="Screen Shot 2019-11-06 at 4 23 32 PM" src="https://user-images.githubusercontent.com/5072991/68295047-4f6e5c00-00b3-11ea-8297-fffeca4de72d.png">

**Why we cannot achieve this from `siteconfiguration` model in ecommerce?**

There is no generic field in `siteconfiguration` model where we can provide these marketing urls. We would need to add a new field (along with migration) to store marketing urls configuration which will be a change in the core ecommerce code and to avoid it we have to store these marketing urls in environment variables `/edx/etc/ecommerce.yml`
```yml
MARKETING_SITE_ROOT: https://dev.edly.io
MKTG_URLS:
    TOS: /terms-of-service
    HONOR: /honor-code
    PRIVACY: /privacy-policy
```

Here is the current ecommerce site configuration:
<img width="777" alt="Screen Shot 2019-11-06 at 4 38 56 PM" src="https://user-images.githubusercontent.com/5072991/68295585-85601000-00b4-11ea-94c2-166c6ffcbdb2.png">
<img width="767" alt="Screen Shot 2019-11-06 at 4 39 07 PM" src="https://user-images.githubusercontent.com/5072991/68295593-88f39700-00b4-11ea-99df-e8c861dc8bf7.png">



