### PR TITLE
fix edly app context processor tests

### DIFF
--- a/ecommerce/extensions/edly_ecommerce_app/tests/test_context_processor.py
+++ b/ecommerce/extensions/edly_ecommerce_app/tests/test_context_processor.py
@@ -2,7 +2,6 @@
 Unit tests for edly_app context_processor
 """
 
-from django.conf import settings
 from django.test import RequestFactory
 from ecommerce.extensions.edly_ecommerce_app.context_processor import edly_app_context
 from ecommerce.tests.testcases import TestCase
@@ -22,20 +21,22 @@ class EdlyAppContextProcessorTests(TestCase):
         self.assertDictEqual(
             edly_app_context(self.request),
             {
-                'services_notifications_url': "",
-                'session_cookie_domain': settings.SESSION_COOKIE_DOMAIN,
+                'session_cookie_domain': self.site_configuration.base_cookie_domain,
+                'services_notifications_url': '',
                 'services_notifications_cookie_expiry': 180
             }
         )
 
     def test_custom_edly_app_context(self):
         test_config_values = {
-            "PANEL_NOTIFICATIONS_BASE_URL": "http://panel.backend.dev.edly.com:9999",
-            "SESSION_COOKIE_DOMAIN": ".test.com",
-            "SERVICES_NOTIFICATIONS_COOKIE_EXPIRY": "360"
+            'PANEL_NOTIFICATIONS_BASE_URL': 'http://panel.backend.dev.edly.com:9998',
+            'SERVICES_NOTIFICATIONS_COOKIE_EXPIRY': 360,
         }
 
-        self.request.site.siteconfiguration.configuration_values = test_config_values
+        site_configuration = self.request.site.siteconfiguration
+        site_configuration.edly_client_theme_branding_settings = test_config_values
+        site_configuration.save()
+
         test_panel_services_notifications_url = '{base_url}/api/v1/all_services_notifications/'.format(
             base_url=test_config_values['PANEL_NOTIFICATIONS_BASE_URL']
         )
@@ -43,8 +44,8 @@ class EdlyAppContextProcessorTests(TestCase):
         self.assertDictEqual(
             edly_app_context(self.request),
             {
+                'session_cookie_domain': site_configuration.base_cookie_domain,
                 'services_notifications_url': test_panel_services_notifications_url,
-                'session_cookie_domain': test_config_values['SESSION_COOKIE_DOMAIN'],
-                'services_notifications_cookie_expiry': test_config_values['SERVICES_NOTIFICATIONS_COOKIE_EXPIRY']
+                'services_notifications_cookie_expiry': test_config_values['SERVICES_NOTIFICATIONS_COOKIE_EXPIRY'],
             }
         )


### PR DESCRIPTION
* Fix edly app context processor failing tests (https://github.com/edly-io/ecommerce/pull/10/)
* Remove unused imports
* Rename and order file variables `ecommerce/extensions/edly_ecommerce_app/context_processor.py`
* Use single quotes `'` in code

**Testing Instructions:**

1. Run ECOM shell `make ecommerce-shell`
2. Run ECOM tests using command `REUSE_DB=1 DISABLE_ACCEPTANCE_TESTS=True ./manage.py test ecommerce/extensions/edly_ecommerce_app/tests/ --settings=ecommerce.settings.test --logging-level=DEBUG`

<img width="1387" alt="Screen Shot 2020-05-20 at 10 30 19 AM" src="https://user-images.githubusercontent.com/5072991/82408480-14e37400-9a85-11ea-8329-f3f660039079.png">
