### PR TITLE
Hide non edly cloud options from ECOMMERCE

### DIFF
--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -754,6 +754,16 @@ define([
                 this.stickit();
 
                 this.toggleCatalogTypeField();
+
+                if (window.waffle.SWITCHES['enable_non_edly_cloud_options_switch']) {
+                    this.toggleEnterpriseRelatedFields(false);
+                } else {
+                    this.toggleEnterpriseRelatedFields(true);
+                    this.toggleCourseCatalogRelatedFields(true);
+                    this.$('.catalog-type input').attr('disabled', true);
+                    this.$('.catalog-type').parent().addClass('hidden');
+                }
+
                 this.dynamic_catalog_view.setElement(this.$('.catalog_buttons')).render();
 
                 this.$('.row:first').before(AlertDivTemplate);


### PR DESCRIPTION
**Description:** This PR hides the non-edly cloud options based on the value of waffle switch `enable_non_edly_cloud_options_switch`

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-1315

**Related themes PR:** https://github.com/edly-io/edly-edx-themes/pull/167

**Merge checklist:**

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Note:** Please add screenshots for any viewable change.
<img width="1633" alt="Screenshot 2020-05-21 at 2 07 51 PM" src="https://user-images.githubusercontent.com/17013371/82545022-76800d00-9b6f-11ea-8f02-b0c6d3094fa2.png">