### PR TITLE
Redirect blue site user to red site's login page

### DIFF
--- a/ecommerce/extensions/edly_ecommerce_app/middleware.py
+++ b/ecommerce/extensions/edly_ecommerce_app/middleware.py
@@ -1,7 +1,9 @@
 from logging import getLogger
 from django.conf import settings
+from django.contrib.auth import logout
 from django.contrib.sites.shortcuts import get_current_site
-from django.http import Http404
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 
 from ecommerce.core.models import SiteConfiguration
 from ecommerce.extensions.edly_ecommerce_app.helpers import user_has_edly_organization_access
@@ -47,4 +49,5 @@ class EdlyOrganizationAccessMiddleware(object):
         user_is_superuser = request.user.is_superuser
         if user_is_authenticated and not user_is_superuser and not user_has_edly_organization_access(request):
             logger.exception('Edly user %s has no access for site %s.' % (request.user.email, request.site))
-            raise Http404()
+            logout(request)
+            return HttpResponseRedirect(reverse('logout'))

--- a/ecommerce/extensions/edly_ecommerce_app/tests/test_middlewares.py
+++ b/ecommerce/extensions/edly_ecommerce_app/tests/test_middlewares.py
@@ -119,9 +119,9 @@ class EdlyOrganizationAccessMiddlewareTests(TestCase):
 
     def test_user_without_edly_organization_access(self):
         """
-        Verify that logged in user gets valid error and log message response if user has no access.
+        Verify that logged in user gets redirected to logout page and valid log message response if user has no access.
 
-        Test that logged in user gets 404 and valid log message if user has no access for
+        Test that logged in user gets redirected to logout page and valid log message if user has no access for
         request site's edly sub organization.
         """
 


### PR DESCRIPTION
**Description:**  This PR adds the implementation to redirect one site user to other site’s logout page if one site user tries to access any other site’s ECOM URL’s

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1380

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
<img width="1296" alt="Screenshot 2020-06-01 at 5 10 39 PM" src="https://user-images.githubusercontent.com/17013371/83407766-d8235f80-a42a-11ea-99e4-e1e29913ce5f.png">
