### PR TITLE
Hitting red site url while signed in on blue site leads to logout url…

### DIFF
--- a/ecommerce/extensions/edly_ecommerce_app/middleware.py
+++ b/ecommerce/extensions/edly_ecommerce_app/middleware.py
@@ -50,4 +50,4 @@ class EdlyOrganizationAccessMiddleware(object):
         if user_is_authenticated and not user_is_superuser and not user_has_edly_organization_access(request):
             logger.exception('Edly user %s has no access for site %s.' % (request.user.email, request.site))
             if request.path != '/logout':
-                return HttpResponseRedirect(reverse('logout'))
+                return HttpResponseRedirect(settings.FRONTEND_LOGOUT_URL)

--- a/ecommerce/extensions/edly_ecommerce_app/tests/test_middlewares.py
+++ b/ecommerce/extensions/edly_ecommerce_app/tests/test_middlewares.py
@@ -127,7 +127,7 @@ class EdlyOrganizationAccessMiddlewareTests(TestCase):
 
         with LogCapture(logger.name) as logs:
             response = self.client.get(self.basket_url)
-            self.assertRedirects(response, '/logout/', target_status_code=302)
+            self.assertRedirects(response, settings.FRONTEND_LOGOUT_URL, target_status_code=302)
             user = auth.get_user(self.client)
             assert not user.is_authenticated()
 


### PR DESCRIPTION
**Description:**
Used LMS URL of the current site to attempt logout.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-1421

**Related PR in LMS/Studio:**  https://github.com/edly-io/edx-platform/pull/97

**Testing instruction:**
Sign in to Red Site, try to hit Blue site URL. It should first log out you on the Red site before going to the login of Blue site.