### PR TITLE
EDLY_1393 Fix E-Commerce: Layout broken when coupon form has error.

### DIFF
--- a/ecommerce/static/js/views/form_view.js
+++ b/ecommerce/static/js/views/form_view.js
@@ -172,6 +172,10 @@ define([
                         console.error(message); // eslint-disable-line no-console
                     } else {
                         // Log the error to the console for debugging purposes
+                        if (typeof response.responseJSON === 'string' || response.responseJSON instanceof String){
+                            response.responseJSON = Array(response.responseJSON);
+                        }
+
                         for (var key in response.responseJSON) {
                             AlertUtils.renderAlert('danger', gettext('Error!'), response.responseJSON[key], self);
                         }


### PR DESCRIPTION
Description:
Used requested site URL to attempt logout.

Before:
<img width="1251" alt="Screenshot 2020-06-10 at 11 12 03 AM" src="https://user-images.githubusercontent.com/15142776/84234445-b81c2c00-ab0d-11ea-87d2-5dc42cfade47.png">

Now:
<img width="1251" alt="Screenshot 2020-06-10 at 10 57 08 AM" src="https://user-images.githubusercontent.com/15142776/84234484-c9fdcf00-ab0d-11ea-940d-33c2707dfee9.png">

Tested with other errors too:
<img width="1251" alt="Screenshot 2020-06-10 at 11 23 06 AM" src="https://user-images.githubusercontent.com/15142776/84234492-cec28300-ab0d-11ea-99c8-f89bf7ab06af.png">


JIRA:
https://edlyio.atlassian.net/browse/EDLY-1393


Testing instruction:
Fill form with these values to test it
![image-20200604-143407](https://user-images.githubusercontent.com/15142776/84234438-b0f51e00-ab0d-11ea-810f-fc15e47a2012.png)

