### PR TITLE
Updated logout url check logic

### DIFF
--- a/ecommerce/extensions/edly_ecommerce_app/middleware.py
+++ b/ecommerce/extensions/edly_ecommerce_app/middleware.py
@@ -49,5 +49,5 @@ class EdlyOrganizationAccessMiddleware(object):
         user_is_superuser = request.user.is_superuser
         if user_is_authenticated and not user_is_superuser and not user_has_edly_organization_access(request):
             logger.exception('Edly user %s has no access for site %s.' % (request.user.email, request.site))
-            if request.path != '/logout':
+            if 'logout' not in request.path:
                 return HttpResponseRedirect(reverse('logout'))


### PR DESCRIPTION
Description:
Updated logout url check logic. We had `'/logout'` URL in our check logic but our actual logout URL is `'/logout/'`. This logic checks if logout is substring of request.path would not request logout.

This PR actually reverts previous changes done in these PRs 
https://github.com/edly-io/ecommerce/pull/23
https://github.com/edly-io/ecommerce/pull/24

Related PR in edx (https://github.com/edly-io/edx-platform/pull/100)

JIRA:
https://edlyio.atlassian.net/browse/EDLY-1421

Related PR in LMS/Studio: https://github.com/edly-io/edx-platform/pull/97

Testing instruction:
Sign in to Red Site, try to hit Blue site URL. It should first log out you and redirect to the login of Blue site.