### PR TITLE
Add platform_name in email context from configuration helper

### DIFF
--- a/ecommerce/notifications/notifications.py
+++ b/ecommerce/notifications/notifications.py
@@ -31,7 +31,7 @@ def send_notification(user, commtype_code, context, site):
     context.update({
         'full_name': full_name,
         'site_domain': site.domain,
-        'platform_name': site.name,
+        'platform_name': configuration_helpers.get('PLATFORM_NAME', site.name),
         'tracking_pixel': tracking_pixel,
         'edly_mailing_address': configuration_helpers.get('CONTACT_MAILING_ADDRESS'),
         'edly_copyright_text': configuration_helpers.get('EDLY_COPYRIGHT_TEXT'),


### PR DESCRIPTION
**Description**:
Added platform name in email context from configuration helper.
**JIRA**:
https://edlyio.atlassian.net/browse/EDLY-1534
**Testing:**
Try buying a course & see email on devmultisite main site.
**Screenshots:**

Before:
<img width="602" alt="Screenshot 2020-06-25 at 12 15 31 PM" src="https://user-images.githubusercontent.com/15142776/85722268-8c06ca80-b70b-11ea-8410-3c6031af9409.png">

After:
<img width="789" alt="Screenshot 2020-06-25 at 5 41 21 PM" src="https://user-images.githubusercontent.com/15142776/85722312-96c15f80-b70b-11ea-94ab-53e95ed4289f.png">
