### PR TITLE
Add paramter to bypass partner based filtering

### DIFF
--- a/ecommerce/extensions/api/v2/views/courses.py
+++ b/ecommerce/extensions/api/v2/views/courses.py
@@ -33,6 +33,12 @@ class CourseViewSet(NonDestroyableModelViewSet):
 
     def get_queryset(self):
         site_configuration = self.request.site.siteconfiguration
+
+        if bool(self.request.GET.get('include_all_partners'), False):
+            return Course.objects.all().prefetch_related(
+                self.products_prefetch, self.product_attribute_value_prefetch, 'products__stockrecords'
+            )
+
         return Course.objects.filter(partner=site_configuration.partner).prefetch_related(
             self.products_prefetch, self.product_attribute_value_prefetch, 'products__stockrecords'
         )
@@ -44,6 +50,12 @@ class CourseViewSet(NonDestroyableModelViewSet):
         parameters:
             - name: include_products
               description: Indicates if the related products should be included in the response.
+              required: false
+              type: boolean
+              paramType: query
+              multiple: false
+            - name: include_all_partners
+              description: Indicates if the all parnters data needs to be pulled.
               required: false
               type: boolean
               paramType: query


### PR DESCRIPTION
**Description**: Added parameter to bypass partner based filtering

We found that course-discovery has an e-commerce API URL to pull data form e-commerce and e-commerce uses partner based filtering to return seats data.
We are moving towards adding a ?include_all_partners=True parameter in API URL of e-commerce that can ignore partner based filtering of data in eCommerce service.

JIRA:https://edlyio.atlassian.net/browse/EDLY-1636

Related PR in course discovery service: https://github.com/edly-io/course-discovery/pull/6