### PR TITLE
Made subscription display order editable and added back the id field

### DIFF
--- a/ecommerce/static/js/views/subscription_list_view.js
+++ b/ecommerce/static/js/views/subscription_list_view.js
@@ -45,7 +45,6 @@ define([
             renderSubscriptionTable: function() {
                 var filterPlaceholder = gettext('Search...'),
                     $emptyLabel = '<label class="sr">' + filterPlaceholder + '</label>';
-                SubscriptionUtils.setCoursePaymentsButtonText();
 
                 if (!$.fn.dataTable.isDataTable('#subscriptionTable')) {
                     this.$el.find('#subscriptionTable').DataTable({

--- a/ecommerce/static/templates/subscription_form.html
+++ b/ecommerce/static/templates/subscription_form.html
@@ -98,7 +98,7 @@
         <div class="form-group">
             <label class="hd-4" for="display-order"><%= gettext('Subscription Display Order') %></label>
             <div class="input-group">
-                <input id="display-order" type="number" step="1" class="form-control non-editable" name="display_order" min="1" >
+                <input id="display-order" type="number" step="1" class="form-control" name="display_order" min="1" >
             </div>
             <p class="help-block"><%= gettext('Display order for the subscription in which learners will see it in the list of subscriptions. (1 being the highest order)') %></p>
         </div>

--- a/ecommerce/subscriptions/api/v2/serializers.py
+++ b/ecommerce/subscriptions/api/v2/serializers.py
@@ -92,7 +92,7 @@ class SubscriptionListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
         fields = [
-            'title', 'subscription_type', 'subscription_actual_price', 'subscription_price',
+            'id', 'title', 'subscription_type', 'subscription_actual_price', 'subscription_price',
             'subscription_status', 'display_order', 'partner_sku', 'is_course_payments_enabled'
         ]
 
@@ -325,6 +325,6 @@ class SubscriptionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
         fields = (
-            'title', 'subscription_type', 'subscription_actual_price', 'subscription_price', 'subscription_status',
+            'id', 'title', 'subscription_type', 'subscription_actual_price', 'subscription_price', 'subscription_status',
             'subscription_number_of_courses', 'subscription_duration_value', 'subscription_duration_unit'
         )

--- a/ecommerce/subscriptions/api/v2/tests/test_serializers.py
+++ b/ecommerce/subscriptions/api/v2/tests/test_serializers.py
@@ -33,6 +33,7 @@ class SubscriptionListSerializerTests(SubscriptionProductMixin, TestCase):
         }
         subscription = self.create_subscription()
         expected_data = {
+            'id': subscription.id,
             'title': subscription.title,
             'subscription_type': subscription.attr.subscription_type.option,
             'subscription_actual_price': subscription.attr.subscription_actual_price,
@@ -89,6 +90,7 @@ class SubscriptionSerializerTests(SubscriptionProductMixin, TestCase):
             },
         }
         expected_data = {
+            'id': subscription.id,
             'title': subscription.title,
             'subscription_type': subscription_type,
             'subscription_actual_price': subscription.attr.subscription_actual_price,

--- a/ecommerce/subscriptions/api/v2/tests/test_views.py
+++ b/ecommerce/subscriptions/api/v2/tests/test_views.py
@@ -22,7 +22,7 @@ class SubscriptionViewSetTests(SubscriptionProductMixin, TestCase):
         """
         self.create_subscription(stockrecords__partner=self.site.partner)
         expected_keys = [
-            'title', 'subscription_type', 'subscription_actual_price', 'subscription_price', 'subscription_status',
+            'id', 'title', 'subscription_type', 'subscription_actual_price', 'subscription_price', 'subscription_status',
             'display_order', 'partner_sku', 'is_course_payments_enabled'
         ]
         request_url = reverse('api:v2:subscriptions-list')


### PR DESCRIPTION
**Description:**
This PR makes the `subscription_display_order` field editable in ecommerce. This also adds `id` field back as it is needed in the subscription list page on ecommerce.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2212