### PR TITLE
Add description in subscription listing api EDLY 2211

### DIFF
--- a/ecommerce/subscriptions/api/v2/serializers.py
+++ b/ecommerce/subscriptions/api/v2/serializers.py
@@ -46,6 +46,12 @@ class SubscriptionListSerializer(serializers.ModelSerializer):
     display_order = serializers.SerializerMethodField()
     is_course_payments_enabled = serializers.SerializerMethodField()
 
+    def get_description(self, product):
+        """
+        Get description for a subscription.
+        """
+        return product.attr.description
+
     def get_subscription_type(self, product):
         """
         Get selected subscription type for a subscription.
@@ -92,7 +98,7 @@ class SubscriptionListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product
         fields = [
-            'id', 'title', 'date_created', 'subscription_type', 'subscription_actual_price', 'subscription_price',
+            'id', 'title', 'description', 'date_created', 'subscription_type', 'subscription_actual_price', 'subscription_price',
             'subscription_status', 'display_order', 'partner_sku', 'is_course_payments_enabled'
         ]
 

--- a/ecommerce/subscriptions/api/v2/tests/test_serializers.py
+++ b/ecommerce/subscriptions/api/v2/tests/test_serializers.py
@@ -36,6 +36,7 @@ class SubscriptionListSerializerTests(SubscriptionProductMixin, TestCase):
         expected_data = {
             'id': subscription.id,
             'title': subscription.title,
+            'description': subscription.description,
             'date_created': date_created,
             'subscription_type': subscription.attr.subscription_type.option,
             'subscription_actual_price': subscription.attr.subscription_actual_price,

--- a/ecommerce/subscriptions/api/v2/tests/test_views.py
+++ b/ecommerce/subscriptions/api/v2/tests/test_views.py
@@ -47,7 +47,7 @@ class SubscriptionViewSetTests(SubscriptionProductMixin, TestCase):
         """
         self.create_subscription(stockrecords__partner=self.site.partner)
         expected_keys = [
-            'id', 'title', 'date_created', 'subscription_type', 'subscription_actual_price', 'subscription_price',
+            'id', 'title', 'description', 'date_created', 'subscription_type', 'subscription_actual_price', 'subscription_price',
             'subscription_status', 'display_order', 'partner_sku', 'is_course_payments_enabled'
         ]
         request_url = reverse('api:v2:subscriptions-list')


### PR DESCRIPTION
Description: Add description in subscription list api in ECOM.

JIRA:
https://edlyio.atlassian.net/browse/EDLY-2211

**Visible Changes**:

`description` wasn't present
<img width="945" alt="Screenshot 2020-11-30 at 12 17 25 PM" src="https://user-images.githubusercontent.com/68893403/100865679-761ae400-34b9-11eb-8f2b-3d5adf82b6c0.png">

`description` added.
<img width="968" alt="Screenshot 2020-12-01 at 9 35 59 AM" src="https://user-images.githubusercontent.com/68893403/100865810-a5315580-34b9-11eb-9656-7ca7622792ae.png">

