### PR TITLE
Revert edx tests and fix edly tests EDLY-2414

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -13,7 +13,6 @@ import six.moves.urllib.parse  # pylint: disable=import-error
 import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
 from django.http import HttpResponseRedirect
-from django.test import modify_settings
 from django.urls import reverse
 from django.utils.timezone import now
 from factory.fuzzy import FuzzyText
@@ -63,9 +62,6 @@ def format_url(base='', path='', params=None):
     return '{base}{path}'.format(base=base, path=path)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CouponAppViewTests(TestCase):
     path = reverse('coupons:app', args=[''])
 
@@ -89,9 +85,6 @@ class CouponAppViewTests(TestCase):
         self.assert_response_status(is_staff=True, status_code=200)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class VoucherIsValidTests(DiscoveryTestMixin, TestCase):
     def test_valid_voucher(self):
         """ Verify voucher_is_valid() assess that the voucher is valid. """
@@ -173,9 +166,6 @@ class VoucherIsValidTests(DiscoveryTestMixin, TestCase):
         self.assert_error_messages(voucher, product, user, error_msg)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class CouponOfferViewTests(ApiMockMixin, CouponMixin, DiscoveryTestMixin, EnterpriseServiceMockMixin,
                            LmsApiMockMixin, TestCase):
@@ -315,9 +305,6 @@ class CouponOfferViewTests(ApiMockMixin, CouponMixin, DiscoveryTestMixin, Enterp
         self.assertContains(response, expected_response, status_code=200)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, EnterpriseServiceMockMixin,
                             TestCase, DiscoveryMockMixin):
@@ -840,9 +827,6 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         return self.get_full_url(path=reverse('basket:summary')) + '?coupon_redeem_redirect=1'
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class EnrollmentCodeCsvViewTests(TestCase):
     """ Tests for the EnrollmentCodeCsvView view. """

--- a/ecommerce/courses/tests/test_views.py
+++ b/ecommerce/courses/tests/test_views.py
@@ -5,7 +5,6 @@ import json
 import ddt
 import httpretty
 from django.conf import settings
-from django.test import modify_settings
 from django.urls import reverse
 from edx_django_utils.cache import TieredCache
 from mock import patch
@@ -47,23 +46,14 @@ class ManagementCommandViewMixin:
         self.assertEqual(response.status_code, 200)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CourseMigrationViewTests(ManagementCommandViewMixin, TestCase):
     path = reverse('courses:migrate')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ConvertCourseViewTests(ManagementCommandViewMixin, TestCase):
     path = reverse('courses:convert_course')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class CourseAppViewTests(TestCase):
     path = reverse('courses:app', args=[''])

--- a/ecommerce/credit/tests/test_views.py
+++ b/ecommerce/credit/tests/test_views.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 import ddt
 import httpretty
 from django.conf import settings
-from django.test import modify_settings
 from django.urls import reverse
 from django.utils import timezone
 from oscar.core.loading import get_model
@@ -28,9 +27,6 @@ JSON = 'application/json'
 Benefit = get_model('offer', 'Benefit')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
     """Test for Checkout page"""

--- a/ecommerce/enterprise/tests/test_views.py
+++ b/ecommerce/enterprise/tests/test_views.py
@@ -4,7 +4,6 @@ import uuid
 
 import httpretty
 from django.conf import settings
-from django.test import modify_settings
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -18,9 +17,6 @@ Benefit = get_model('offer', 'Benefit')
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class EnterpriseOfferListViewTests(EnterpriseServiceMockMixin, ViewTestMixin, TestCase):
 
     path = reverse('enterprise:offers:list')
@@ -79,9 +75,6 @@ class EnterpriseOfferListViewTests(EnterpriseServiceMockMixin, ViewTestMixin, Te
         self.assertEqual(list(response.context['object_list']), [partner_conditional_offer])
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class EnterpriseOfferUpdateViewTests(EnterpriseServiceMockMixin, ViewTestMixin, TestCase):
 
     def setUp(self):
@@ -123,9 +116,6 @@ class EnterpriseOfferUpdateViewTests(EnterpriseServiceMockMixin, ViewTestMixin, 
         self.assertRedirects(response, self.path)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @httpretty.activate
 class EnterpriseOfferCreateViewTests(EnterpriseServiceMockMixin, ViewTestMixin, TestCase):
 
@@ -180,9 +170,6 @@ class EnterpriseOfferCreateViewTests(EnterpriseServiceMockMixin, ViewTestMixin, 
         )
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class EnterpriseCouponAppViewTests(TestCase):
     path = reverse('enterprise:coupons', args=[''])
 

--- a/ecommerce/extensions/api/v2/tests/views/test_assignmentemail.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_assignmentemail.py
@@ -5,7 +5,6 @@ import logging
 
 import ddt
 import mock
-from django.test import modify_settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from testfixtures import LogCapture
@@ -16,9 +15,6 @@ from ecommerce.extensions.test import factories
 from ecommerce.tests.testcases import TestCase
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class AssignmentEmailStatusTests(TestCase):
     """ Tests for AssignmentEmailStatus API view. """
@@ -137,9 +133,6 @@ class AssignmentEmailStatusTests(TestCase):
         self.assertEqual(updated_offer_assignment.status, OFFER_ASSIGNED)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class AssignmentEmailBounceTests(TestCase):
     """ Tests for AssignmentEmailBounce API view. """

--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -11,7 +11,7 @@ import httpretty
 import mock
 import six  # pylint: disable=ungrouped-imports
 from django.contrib.auth import get_user_model
-from django.test import modify_settings, override_settings
+from django.test import override_settings
 from django.urls import reverse
 from edx_rest_framework_extensions.auth.jwt.cookies import jwt_cookie_name
 from oscar.core.loading import get_model
@@ -57,9 +57,6 @@ LOGGER_NAME = 'ecommerce.extensions.api.v2.views.baskets'
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @override_settings(
     FULFILLMENT_MODULES=['ecommerce.extensions.fulfillment.tests.modules.FakeFulfillmentModule']
 )
@@ -289,9 +286,6 @@ class BasketCreateViewTests(BasketCreationMixin, ThrottlingMixin, TransactionTes
         self.assertDictEqual(actual, expected)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class BasketViewSetTests(AccessTokenMixin, ThrottlingMixin, TestCase):
 
     def setUp(self):
@@ -362,9 +356,6 @@ class BasketViewSetTests(AccessTokenMixin, ThrottlingMixin, TestCase):
             self.assertIsNone(response.json()['results'][0]['vouchers'])
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class OrderByBasketRetrieveViewTests(OrderDetailViewTestMixin, TestCase):
     """Test cases for getting orders using the basket id. """
 
@@ -382,9 +373,6 @@ class OrderByBasketRetrieveViewTests(OrderDetailViewTestMixin, TestCase):
         self.assertEqual(response.data, self.serialize_order(self.order))
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class BasketDestroyViewTests(TestCase):
     def setUp(self):
         super(BasketDestroyViewTests, self).setUp()
@@ -409,9 +397,6 @@ class BasketDestroyViewTests(TestCase):
         self.assertFalse(Basket.objects.filter(id=self.basket.id).exists())
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
     def setUp(self):
         super(BasketCalculateViewTests, self).setUp()

--- a/ecommerce/extensions/api/v2/tests/views/test_catalog.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_catalog.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import ddt
 import httpretty
 import mock
-from django.test import modify_settings
 from django.urls import reverse
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
@@ -21,9 +20,6 @@ Catalog = get_model('catalogue', 'Catalog')
 StockRecord = get_model('partner', 'StockRecord')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @httpretty.activate
 @ddt.ddt
 class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCase):
@@ -167,9 +163,6 @@ class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCas
         self.assertEqual(response.data.get('results'), [])
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class PartnerCatalogViewSetTest(CatalogMixin, TestCase):
     def setUp(self):
         super(PartnerCatalogViewSetTest, self).setUp()

--- a/ecommerce/extensions/api/v2/tests/views/test_checkout.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_checkout.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
-from django.test import modify_settings, override_settings
+from django.test import override_settings
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -12,9 +12,6 @@ from ecommerce.tests.testcases import TestCase
 Basket = get_model('basket', 'Basket')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class DummyProcessorWithUrl(DummyProcessor):
     """ Dummy payment processor class that has a test payment page url. """
     NAME = 'dummy_with_url'
@@ -27,9 +24,6 @@ class DummyProcessorWithUrl(DummyProcessor):
         return dummy_values
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CheckoutViewTests(TestCase):
     """ Tests for CheckoutView API view. """
     path = reverse('api:v2:checkout:process')

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -12,7 +12,6 @@ import mock
 import pytz
 import six
 from django.test import RequestFactory
-from django.test import modify_settings
 from django.urls import reverse
 from django.utils.timezone import now
 from oscar.core.loading import get_model
@@ -60,9 +59,6 @@ TEST_CATEGORIES = ['Financial Assistance', 'Partner No Rev - RAP', 'Geography Pr
 
 
 @httpretty.activate
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CouponViewSetTest(CouponMixin, DiscoveryTestMixin, TestCase):
     def setUp(self):
         super(CouponViewSetTest, self).setUp()
@@ -224,9 +220,6 @@ class CouponViewSetTest(CouponMixin, DiscoveryTestMixin, TestCase):
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixin, ThrottlingMixin,
                                   TestCase):
     """Test the coupon order creation functionality."""
@@ -1300,9 +1293,6 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         assert coupon.attr.enterprise_contract_metadata.amount_paid == Decimal('99009900.00')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CouponCategoriesListViewTests(TestCase):
     """ Tests for the coupon category list view. """
     path = reverse('api:v2:coupons:coupons_categories')

--- a/ecommerce/extensions/api/v2/tests/views/test_courses.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_courses.py
@@ -6,7 +6,6 @@ import jwt
 import mock
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.test import modify_settings
 from django.urls import reverse
 from oscar.core.loading import get_class, get_model
 
@@ -25,9 +24,6 @@ Selector = get_class('partner.strategy', 'Selector')
 User = get_user_model()
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CourseViewSetTests(ProductSerializerMixin, DiscoveryTestMixin, TestCase):
     list_path = reverse('api:v2:course-list')
 

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -13,7 +13,7 @@ import mock
 import rules
 import six  # pylint: disable=ungrouped-imports
 from django.conf import settings
-from django.test import modify_settings, override_settings
+from django.test import override_settings
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.timezone import now
@@ -68,9 +68,6 @@ TEMPLATE_GREETING = 'hello there '
 TEMPLATE_CLOSING = ' kind regards'
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class TestEnterpriseCustomerView(EnterpriseServiceMockMixin, TestCase):
 
     dummy_enterprise_customer_data = [
@@ -116,9 +113,6 @@ class TestEnterpriseCustomerView(EnterpriseServiceMockMixin, TestCase):
         )
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class TestEnterpriseCustomerCatalogsViewSet(EnterpriseServiceMockMixin, TestCase):
 
     def setUp(self):
@@ -280,9 +274,6 @@ class TestEnterpriseCustomerCatalogsViewSet(EnterpriseServiceMockMixin, TestCase
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class EnterpriseCouponViewSetRbacTests(
         CouponMixin,
         DiscoveryTestMixin,
@@ -2692,9 +2683,6 @@ class EnterpriseCouponViewSetRbacTests(
         }
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class OfferAssignmentSummaryViewSetTests(
         CouponMixin,
         DiscoveryTestMixin,
@@ -2857,9 +2845,6 @@ class OfferAssignmentSummaryViewSetTests(
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class OfferAssignmentEmailTemplatesViewSetTests(JwtMixin, TestCase):
     """
     Test the enterprise offer assignment templates functionality with role based access control.

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -11,7 +11,7 @@ import pytz
 import six
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-from django.test import modify_settings, override_settings, RequestFactory
+from django.test import RequestFactory, override_settings
 from django.urls import reverse
 from oscar.core.loading import get_class, get_model
 from rest_framework import status
@@ -37,9 +37,6 @@ User = get_user_model()
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
     def setUp(self):
         super(OrderListViewTests, self).setUp()
@@ -217,9 +214,6 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
 
 @ddt.ddt
 @override_settings(ECOMMERCE_SERVICE_WORKER_USERNAME='test-service-user')
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class OrderFulfillViewTests(TestCase):
     def setUp(self):
         super(OrderFulfillViewTests, self).setUp()
@@ -356,9 +350,6 @@ class OrderFulfillViewTests(TestCase):
         post_checkout.send.assert_called_once_with(**send_arguments)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class OrderDetailViewTests(OrderDetailViewTestMixin, TestCase):
     @property
     def url(self):
@@ -366,9 +357,6 @@ class OrderDetailViewTests(OrderDetailViewTestMixin, TestCase):
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ManualCourseEnrollmentOrderViewSetTests(TestCase):
     """
     Test the `ManualCourseEnrollmentOrderViewSet` functionality.

--- a/ecommerce/extensions/api/v2/tests/views/test_partners.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_partners.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from django.test import modify_settings
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -10,9 +9,6 @@ from ecommerce.tests.testcases import TestCase
 Partner = get_model('partner', 'Partner')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class PartnerViewTest(TestCase):
     def setUp(self):
         super(PartnerViewTest, self).setUp()

--- a/ecommerce/extensions/api/v2/tests/views/test_payments.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_payments.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.test import modify_settings, override_settings
+from django.test import override_settings
 from django.urls import reverse
 from edx_django_utils.cache import TieredCache
 
@@ -11,9 +11,6 @@ from ecommerce.extensions.payment.tests.processors import AnotherDummyProcessor,
 from ecommerce.tests.testcases import TestCase
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class PaymentProcessorListViewTests(TestCase):
     """ Ensures correct behavior of the payment processors list view."""
 

--- a/ecommerce/extensions/api/v2/tests/views/test_products.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_products.py
@@ -6,7 +6,7 @@ import uuid
 
 import ddt
 import pytz
-from django.test import modify_settings, RequestFactory
+from django.test import RequestFactory
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -28,9 +28,6 @@ Voucher = get_model('voucher', 'Voucher')
 PRODUCT_LIST_PATH = reverse('api:v2:product-list')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ProductViewSetBase(ProductSerializerMixin, DiscoveryTestMixin, TestCase):
     def setUp(self):
         super(ProductViewSetBase, self).setUp()
@@ -43,9 +40,6 @@ class ProductViewSetBase(ProductSerializerMixin, DiscoveryTestMixin, TestCase):
         self.seat = self.course.create_or_update_seat('honor', False, 0, expires=expires)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ProductViewSetTests(ProductViewSetBase):
     def test_list(self):
         """The list endpoint should return only products with current site's partner."""
@@ -144,9 +138,6 @@ class ProductViewSetTests(ProductViewSetBase):
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ProductViewSetCourseEntitlementTests(ProductViewSetBase):
     def setUp(self):
         self.entitlement_data = {
@@ -187,9 +178,6 @@ class ProductViewSetCourseEntitlementTests(ProductViewSetBase):
         self.assertEqual(response.data, error_message)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ProductViewSetCouponTests(CouponMixin, ProductViewSetBase):
     def test_coupon_product_details(self):
         """Verify the endpoint returns all coupon information."""

--- a/ecommerce/extensions/api/v2/tests/views/test_providers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_providers.py
@@ -4,7 +4,6 @@ import json
 
 import ddt
 import httpretty
-from django.test import modify_settings
 from django.urls import reverse
 from rest_framework import status
 
@@ -13,9 +12,6 @@ from ecommerce.tests.testcases import TestCase
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ProvidersViewSetTest(TestCase):
     path = reverse('api:v2:providers:list_providers')
 

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -7,7 +7,6 @@ from decimal import Decimal
 
 import mock
 import pytz
-from django.test import modify_settings
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -33,9 +32,6 @@ EXPIRES = datetime(year=1992, month=4, day=24, tzinfo=pytz.utc)
 EXPIRES_STRING = EXPIRES.strftime(ISO_8601_FORMAT)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class AtomicPublicationTests(DiscoveryTestMixin, TestCase):
     def setUp(self):
         super(AtomicPublicationTests, self).setUp()

--- a/ecommerce/extensions/api/v2/tests/views/test_refunds.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_refunds.py
@@ -5,7 +5,6 @@ import json
 import ddt
 import httpretty
 import mock
-from django.test import modify_settings
 from django.urls import reverse
 from oscar.core.loading import get_model
 from rest_framework import status
@@ -27,9 +26,6 @@ Option = get_model('catalogue', 'Option')
 Refund = get_model('refund', 'Refund')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class RefundCreateViewTests(RefundTestMixin, AccessTokenMixin, JwtMixin, TestCase):
     MODEL_LOGGER_NAME = 'ecommerce.core.models'
     path = reverse('api:v2:refunds:create')
@@ -294,9 +290,6 @@ class RefundCreateViewTests(RefundTestMixin, AccessTokenMixin, JwtMixin, TestCas
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class RefundProcessViewTests(ThrottlingMixin, TestCase):
     def setUp(self):
         super(RefundProcessViewTests, self).setUp()

--- a/ecommerce/extensions/api/v2/tests/views/test_retirement.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_retirement.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import ddt
-from django.test import modify_settings
 from rest_framework import status
 
 from ecommerce.extensions.analytics.utils import ECOM_TRACKING_ID_FMT
@@ -10,9 +9,6 @@ from ecommerce.tests.testcases import TestCase
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class EcommerceIdViewTest(TestCase):
     def test_successful_get(self):
         user = self.create_user()

--- a/ecommerce/extensions/api/v2/tests/views/test_stockrecords.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_stockrecords.py
@@ -4,7 +4,6 @@ import json
 
 import six
 from django.contrib.auth.models import Permission
-from django.test import modify_settings
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -19,9 +18,6 @@ Product = get_model('catalogue', 'Product')
 StockRecord = get_model('partner', 'StockRecord')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class StockRecordViewSetTests(ProductSerializerMixin, DiscoveryTestMixin, ThrottlingMixin, TestCase):
     list_path = reverse('api:v2:stockrecords-list')
     detail_path = 'api:v2:stockrecords-detail'

--- a/ecommerce/extensions/api/v2/tests/views/test_user_management.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_user_management.py
@@ -4,7 +4,6 @@ import json
 
 import ddt
 import mock
-from django.test import modify_settings
 from django.urls import reverse
 from six.moves import range
 
@@ -16,9 +15,6 @@ JSON_CONTENT_TYPE = 'application/json'
 
 @ddt.ddt
 @mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class UsernameReplacementViewTests(TestCase):
     """ Tests UsernameReplacementView """
     SERVICE_USERNAME = 'test_replace_username_service_worker'

--- a/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
@@ -8,7 +8,6 @@ import httpretty
 import mock
 import pytz
 from django.http import Http404
-from django.test import modify_settings
 from django.urls import reverse
 from django.utils.timezone import now
 from opaque_keys.edx.keys import CourseKey
@@ -46,9 +45,6 @@ Voucher = get_model('voucher', 'Voucher')
 
 
 @ddt.ddt
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class VoucherViewSetTests(DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockMixin, TestCase):
     """ Tests for the VoucherViewSet view set. """
     path = reverse('api:v2:vouchers-list')
@@ -270,9 +266,6 @@ class VoucherViewSetTests(DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockMixi
 
 @ddt.ddt
 @httpretty.activate
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryTestMixin, LmsApiMockMixin,
                                      TestCase):
     """ Tests for the VoucherViewSet offers endpoint. """

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -16,7 +16,7 @@ import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
 from django.contrib.messages import get_messages
 from django.http import HttpResponseRedirect
-from django.test import modify_settings, override_settings
+from django.test import override_settings
 from django.urls import reverse
 from edx_django_utils.cache import RequestCache, TieredCache
 from oscar.apps.basket.forms import BasketVoucherForm
@@ -73,9 +73,6 @@ COUPON_CODE = 'COUPONTEST'
 BUNDLE = 'bundle_identifier'
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class BasketAddItemsViewTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixin, LmsApiMockMixin, BasketMixin,
                               EnterpriseServiceMockMixin, TestCase):
@@ -312,9 +309,6 @@ class BasketAddItemsViewTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixi
         self.assertEqual(response.url, absolute_url(self.request, 'checkout:free-checkout'))
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class BasketLogicTestMixin:
     """ Helper functions for Basket API and BasketSummaryView tests. """
     def create_empty_basket(self):
@@ -379,9 +373,6 @@ class BasketLogicTestMixin:
                 ))
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class PaymentApiResponseTestMixin(BasketLogicTestMixin):
     """
     Helpers for all payment api bff endpoints which return the complete payment api response.
@@ -488,9 +479,6 @@ class PaymentApiResponseTestMixin(BasketLogicTestMixin):
         RequestCache.clear_all_namespaces()
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 @httpretty.activate
 class PaymentApiViewTests(PaymentApiResponseTestMixin, BasketMixin, DiscoveryMockMixin,
@@ -656,9 +644,6 @@ class PaymentApiViewTests(PaymentApiResponseTestMixin, BasketMixin, DiscoveryMoc
         self.assertEqual(response.data['redirect'], absolute_url(self.request, 'checkout:free-checkout'))
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @httpretty.activate
 @ddt.ddt
 class BasketSummaryViewTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, DiscoveryMockMixin, LmsApiMockMixin,
@@ -1098,9 +1083,6 @@ class BasketSummaryViewTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, Dis
         self.assertEqual(response.context['free_basket'], percentage_benefit == 100)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @httpretty.activate
 class VoucherAddMixin(LmsApiMockMixin, DiscoveryMockMixin):
     def setUp(self):
@@ -1328,9 +1310,6 @@ class VoucherAddMixin(LmsApiMockMixin, DiscoveryMockMixin):
             self.assertIn(u'An email has been sent to {}'.format(self.user.email), response.content.decode('utf-8'))
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @httpretty.activate
 class VoucherAddViewTests(VoucherAddMixin, TestCase):
     """ Tests for VoucherAddView. """
@@ -1433,9 +1412,6 @@ class VoucherAddViewTests(VoucherAddMixin, TestCase):
         self.assert_basket_discounts([site_offer])
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @httpretty.activate
 class QuantityApiViewTests(PaymentApiResponseTestMixin, BasketMixin, DiscoveryMockMixin, TestCase):
     """ QuantityApiViewTests basket api tests. """
@@ -1535,9 +1511,6 @@ class QuantityApiViewTests(PaymentApiResponseTestMixin, BasketMixin, DiscoveryMo
         )
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @httpretty.activate
 class VoucherAddApiViewTests(PaymentApiResponseTestMixin, VoucherAddMixin, TestCase):
     """ VoucherAddApiViewTests basket api tests. """
@@ -1580,9 +1553,6 @@ class VoucherAddApiViewTests(PaymentApiResponseTestMixin, VoucherAddMixin, TestC
         )
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @httpretty.activate
 class VoucherRemoveApiViewTests(PaymentApiResponseTestMixin, TestCase):
     """ VoucherRemoveApiViewTests basket api tests. """

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -8,7 +8,6 @@ import six.moves.urllib.error  # pylint: disable=import-error
 import six.moves.urllib.parse  # pylint: disable=import-error
 import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
-from django.test import modify_settings
 from django.urls import reverse
 from mock import patch
 from oscar.core.loading import get_model
@@ -31,9 +30,6 @@ BasketAttributeType = get_model('basket', 'BasketAttributeType')
 Order = get_model('order', 'Order')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
     """ FreeCheckoutView view tests. """
     path = reverse('checkout:free-checkout')
@@ -113,9 +109,6 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CancelCheckoutViewTests(TestCase):
     """ CancelCheckoutView view tests. """
 
@@ -150,9 +143,6 @@ class CancelCheckoutViewTests(TestCase):
         )
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CheckoutErrorViewTests(TestCase):
     """ CheckoutErrorView view tests. """
 
@@ -187,9 +177,6 @@ class CheckoutErrorViewTests(TestCase):
         )
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMixin, TestCase):
     """

--- a/ecommerce/extensions/edly_ecommerce_app/api/v1/views.py
+++ b/ecommerce/extensions/edly_ecommerce_app/api/v1/views.py
@@ -68,6 +68,7 @@ class UserSessionInfo(APIView):
     """
 
     authentication_classes = (SessionAuthentication,)
+    permission_classes = [IsAuthenticated]
 
     def get(self, request):
         csrf_token = csrf.get_token(request)

--- a/ecommerce/extensions/edly_ecommerce_app/helpers.py
+++ b/ecommerce/extensions/edly_ecommerce_app/helpers.py
@@ -28,7 +28,7 @@ def encode_edly_user_info_cookie(cookie_data):
     Returns:
         string
     """
-    return jwt.encode(cookie_data, settings.EDLY_COOKIE_SECRET_KEY, algorithm=settings.EDLY_JWT_ALGORITHM)
+    return jwt.encode(cookie_data, settings.EDLY_COOKIE_SECRET_KEY, algorithm=settings.EDLY_JWT_ALGORITHM).decode('utf-8')
 
 
 def get_edx_org_from_edly_cookie(encoded_cookie_data):

--- a/ecommerce/extensions/edly_ecommerce_app/tests/test_context_processor.py
+++ b/ecommerce/extensions/edly_ecommerce_app/tests/test_context_processor.py
@@ -24,7 +24,8 @@ class EdlyAppContextProcessorTests(TestCase):
                 'session_cookie_domain': self.site_configuration.base_cookie_domain,
                 'services_notifications_url': '',
                 'services_notifications_cookie_expiry': 180,
-                'gtm_id': None
+                'gtm_id': None,
+                'payment_support_email': 'support@example.com',
             }
         )
 
@@ -33,6 +34,7 @@ class EdlyAppContextProcessorTests(TestCase):
             'PANEL_NOTIFICATIONS_BASE_URL': 'http://panel.backend.dev.edly.com:9998',
             'SERVICES_NOTIFICATIONS_COOKIE_EXPIRY': 360,
             'GTM_ID': 'GTM-XXXXXX',
+            'PAYMENT_SUPPORT_EMAIL': 'support@example.com',
         }
 
         site_configuration = self.request.site.siteconfiguration
@@ -50,5 +52,6 @@ class EdlyAppContextProcessorTests(TestCase):
                 'services_notifications_url': test_panel_services_notifications_url,
                 'services_notifications_cookie_expiry': test_config_values['SERVICES_NOTIFICATIONS_COOKIE_EXPIRY'],
                 'gtm_id': test_config_values['GTM_ID'],
+                'payment_support_email': test_config_values['PAYMENT_SUPPORT_EMAIL']
             }
         )

--- a/ecommerce/extensions/edly_ecommerce_app/tests/test_helpers.py
+++ b/ecommerce/extensions/edly_ecommerce_app/tests/test_helpers.py
@@ -43,7 +43,7 @@ class EdlyAppHelperMethodsTests(TestCase):
         expected_encoded_string = jwt.encode(
             self.test_edly_user_info_cookie_data, settings.EDLY_COOKIE_SECRET_KEY,
             algorithm=settings.EDLY_JWT_ALGORITHM
-        )
+        ).decode('utf-8')
         assert actual_encoded_string == expected_encoded_string
 
     def test_decode_edly_user_info_cookie(self):

--- a/ecommerce/extensions/edly_ecommerce_app/tests/test_middlewares.py
+++ b/ecommerce/extensions/edly_ecommerce_app/tests/test_middlewares.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib import auth
 from django.urls import reverse
 from django.test.client import Client
+from django.test import modify_settings
 
 from ecommerce.core.models import SiteConfiguration
 from ecommerce.extensions.edly_ecommerce_app.helpers import encode_edly_user_info_cookie
@@ -116,6 +117,9 @@ class SettingsOverrideMiddlewareTests(TestCase):
         self._assert_settings_values(default_settings)
 
 
+@modify_settings(MIDDLEWARE={
+    'append': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
+})
 class EdlyOrganizationAccessMiddlewareTests(TestCase):
     """
     Tests Edly organization access middleware for sites.
@@ -165,7 +169,7 @@ class EdlyOrganizationAccessMiddlewareTests(TestCase):
             response = self.client.get(self.basket_url)
             self.assertRedirects(response, '/logout/', target_status_code=302)
             user = auth.get_user(self.client)
-            assert not user.is_authenticated()
+            assert not user.is_authenticated
 
             logs.check(
                 (

--- a/ecommerce/extensions/payment/tests/processors/test_signals.py
+++ b/ecommerce/extensions/payment/tests/processors/test_signals.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.test import modify_settings
 from django.urls import reverse
 from edx_django_utils.cache import TieredCache
 from waffle.models import Switch
@@ -10,9 +9,6 @@ from ecommerce.extensions.api.v2.views.payments import PAYMENT_PROCESSOR_CACHE_K
 from ecommerce.tests.testcases import TestCase
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class SignalTests(TestCase):
     def test_invalidate_processor_cache(self):
         """ Verify the payment processor cache is invalidated when payment processor switches are toggled. """

--- a/ecommerce/extensions/payment/tests/views/test_apple_pay.py
+++ b/ecommerce/extensions/payment/tests/views/test_apple_pay.py
@@ -1,16 +1,13 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.test import modify_settings, override_settings
+from django.test import override_settings
 from django.urls import reverse
 
 from ecommerce.extensions.payment.tests.views.test_cybersource import LoginMixin
 from ecommerce.tests.testcases import TestCase
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ApplePayMerchantDomainAssociationViewTests(LoginMixin, TestCase):
     url = reverse('apple_pay_domain_association')
 

--- a/ecommerce/extensions/payment/tests/views/test_authorizenet.py
+++ b/ecommerce/extensions/payment/tests/views/test_authorizenet.py
@@ -1,7 +1,6 @@
 import base64
 import json
 
-from django.test import modify_settings
 from django.urls import reverse
 from lxml import objectify
 from mock import patch
@@ -29,9 +28,6 @@ Product = get_model('catalogue', 'Product')
 NOTIFICATION_TYPE_AUTH_CAPTURE = 'net.authorize.payment.authcapture.created'
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class AuthorizeNetNotificationViewTests(PaymentEventsMixin, TestCase):
     path = reverse('authorizenet:authorizenet_notifications')
 
@@ -379,9 +375,6 @@ class AuthorizeNetNotificationViewTests(PaymentEventsMixin, TestCase):
             Order.objects.filter(number=basket.order_number, total_incl_tax=basket.total_incl_tax).exists())
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class AuthorizeNetRedirectionViewTests(TestCase):
     path = reverse('authorizenet:redirect')
 

--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -10,7 +10,6 @@ import responses
 from django.conf import settings
 from django.contrib.auth import get_user
 from django.test.client import RequestFactory
-from django.test import modify_settings
 from django.urls import reverse
 from freezegun import freeze_time
 from oscar.apps.payment.exceptions import TransactionDeclined
@@ -53,9 +52,6 @@ Source = get_model('payment', 'Source')
 post_checkout = get_class('checkout.signals', 'post_checkout')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class LoginMixin:
     def setUp(self):
         super(LoginMixin, self).setUp()
@@ -63,9 +59,6 @@ class LoginMixin:
         self.client.login(username=self.user.username, password=self.password)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class CybersourceSubmitViewTests(CybersourceMixin, TestCase):
     path = reverse('cybersource:submit')
@@ -224,9 +217,6 @@ class CybersourceSubmitViewTests(CybersourceMixin, TestCase):
         self.assertIn(field, errors)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class CybersourceSubmitAPIViewTests(CybersourceSubmitViewTests):
     path = reverse('cybersource:api_submit')
 
@@ -245,9 +235,6 @@ class CybersourceSubmitAPIViewTests(CybersourceSubmitViewTests):
         super(CybersourceSubmitAPIViewTests, self).test_valid_request()
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class CybersourceInterstitialViewTests(CybersourceNotificationTestsMixin, TestCase):
     """ Test interstitial view for Cybersource Payments. """
@@ -432,9 +419,6 @@ class CybersourceInterstitialViewTests(CybersourceNotificationTestsMixin, TestCa
         self.assertEqual(response.status_code, 302)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class ApplePayStartSessionViewTests(LoginMixin, TestCase):
     url = reverse('cybersource:apple_pay:start_session')
@@ -491,9 +475,6 @@ class ApplePayStartSessionViewTests(LoginMixin, TestCase):
         self.assertEqual(response.data, {'error': 'url is required'})
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class CybersourceApplePayAuthorizationViewTests(LoginMixin, CybersourceMixin, TestCase):
     url = reverse('cybersource:apple_pay:authorize')

--- a/ecommerce/extensions/payment/tests/views/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/views/test_paypal.py
@@ -8,7 +8,6 @@ import httpretty
 import mock
 import responses
 from django.test.client import RequestFactory
-from django.test import modify_settings
 from django.urls import reverse
 from edx_rest_api_client.exceptions import SlumberHttpBaseException
 from oscar.apps.order.exceptions import UnableToPlaceOrder
@@ -55,9 +54,6 @@ SourceType = get_model('payment', 'SourceType')
 post_checkout = get_class('checkout.signals', 'post_checkout')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @ddt.ddt
 class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase):
     """Test handling of users redirected by PayPal after approving payment."""
@@ -475,9 +471,6 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
     # End TODO
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @mock.patch('ecommerce.extensions.payment.views.paypal.call_command')
 class PaypalProfileAdminViewTests(TestCase):
     path = reverse('paypal:profiles')

--- a/ecommerce/extensions/payment/tests/views/test_sdn.py
+++ b/ecommerce/extensions/payment/tests/views/test_sdn.py
@@ -1,14 +1,10 @@
 from __future__ import absolute_import
 
-from django.test import modify_settings
 from django.urls import reverse
 
 from ecommerce.tests.testcases import TestCase
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class SDNFailureTests(TestCase):
     failure_path = reverse('sdn:failure')
 

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import stripe
 from django.conf import settings
-from django.test import modify_settings
 from django.urls import reverse
 from mock import mock
 from oscar.core.loading import get_class, get_model
@@ -31,9 +30,6 @@ Source = get_model('payment', 'Source')
 Product = get_model('catalogue', 'Product')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class StripeSubmitViewTests(PaymentEventsMixin, TestCase):
     path = reverse('stripe:submit')
 

--- a/ecommerce/programs/tests/test_offer.py
+++ b/ecommerce/programs/tests/test_offer.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from decimal import Decimal
 
 import httpretty
-from django.test import modify_settings
 from django.urls import reverse
 from oscar.core.loading import get_class
 from oscar.test.factories import BasketFactory, RangeFactory
@@ -18,9 +17,6 @@ from ecommerce.tests.testcases import TestCase
 Applicator = get_class('offer.applicator', 'Applicator')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ProgramOfferTests(LmsApiMockMixin, ProgramTestMixin, TestCase):
     """ Verification for program offer application. """
 

--- a/ecommerce/programs/tests/test_views.py
+++ b/ecommerce/programs/tests/test_views.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import uuid
 
 import httpretty
-from django.test import modify_settings
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -17,9 +16,6 @@ Benefit = get_model('offer', 'Benefit')
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ProgramOfferListViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
     path = reverse('programs:offers:list')
 
@@ -77,9 +73,6 @@ class ProgramOfferListViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
         self.assertEqual(list(response.context['object_list']), [site_conditional_offer])
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class ProgramOfferUpdateViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
     def setUp(self):
         super(ProgramOfferUpdateViewTests, self).setUp()
@@ -118,9 +111,6 @@ class ProgramOfferUpdateViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
         self.assertRedirects(response, self.path)
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 @httpretty.activate
 class ProgramOfferCreateViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
     path = reverse('programs:offers:new')

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -182,3 +182,7 @@ SAILTHRU_SECRET = 'top_secret'
 
 # Cookie domain
 ECOMMERCE_COOKIE_DOMAIN = "test.edu"
+
+# Remove Edly middleware
+MIDDLEWARE = list(MIDDLEWARE)
+MIDDLEWARE.remove('ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware')

--- a/ecommerce/tests/test_urls.py
+++ b/ecommerce/tests/test_urls.py
@@ -1,15 +1,11 @@
 from __future__ import absolute_import
 
-from django.test import modify_settings
 from django.urls import reverse
 
 from ecommerce.core.url_utils import get_lms_dashboard_url
 from ecommerce.tests.testcases import TestCase
 
 
-@modify_settings(MIDDLEWARE={
-    'remove': 'ecommerce.extensions.edly_ecommerce_app.middleware.EdlyOrganizationAccessMiddleware',
-})
 class TestUrls(TestCase):
     def test_api_docs(self):
         """


### PR DESCRIPTION
**Description:** This pr removes `EdlyOrganizationAccessMiddleware` via `test.py` file to let Open edX runs without any code changes but for the required Edly tests adds `EdlyOrganizationAccessMiddleware` via `modify_settings` decorator. This PR also fixes tests that were overlooked in the previous pr.

Related PR: https://github.com/edly-io/ecommerce/pull/63