### PR TITLE
Text changes from Subscriptions Feedback EDLY_2549

### DIFF
--- a/ecommerce/static/js/utils/subscription_utils.js
+++ b/ecommerce/static/js/utils/subscription_utils.js
@@ -37,11 +37,11 @@ define(['backbone', 'js-cookie', 'underscore'], function (
 					var coursePaymentsButton = $('[name=course-payments]');
 					if (data.course_payments)
 						coursePaymentsButton.text(
-							gettext('Disable Course Payments')
+							gettext('Disable course payments')
 						);
 					else
 						coursePaymentsButton.text(
-							gettext('Enable Course Payments')
+							gettext('Enable course payments')
 						);
 				},
 			});

--- a/ecommerce/static/js/views/confirmation_dialog_view.js
+++ b/ecommerce/static/js/views/confirmation_dialog_view.js
@@ -41,8 +41,8 @@ define([
 		onSuccess: function (data) {
 			var coursePaymentsButton = $('[name=course-payments]');
 			if (data.course_payments)
-				coursePaymentsButton.text(gettext('Disable Course Payments'));
-			else coursePaymentsButton.text(gettext('Enable Course Payments'));
+				coursePaymentsButton.text(gettext('Disable course payments'));
+			else coursePaymentsButton.text(gettext('Enable course payments'));
 			$('#coursePaymentsActionModal').modal('hide');
 		},
 

--- a/ecommerce/static/js/views/subscription_form_view.js
+++ b/ecommerce/static/js/views/subscription_form_view.js
@@ -224,7 +224,7 @@ define([
                         subscription_type: 'limited-access',
                         subscription_active_status: 'active',
                     });
-                    this.$('button[type=submit]').html(gettext('Create Subscription'));
+                    this.$('button[type=submit]').html(gettext('Create plan'));
                 }
 
                 this._super();

--- a/ecommerce/static/templates/subscription_create_edit.html
+++ b/ecommerce/static/templates/subscription_create_edit.html
@@ -10,7 +10,7 @@
     </ol>
     <div class="page-header">
         <h1 class="hd-1 emphasized">
-            <%= gettext(editing ? 'Edit Subscription' : 'Create New Subscription') %>
+            <%= gettext(editing ? 'Edit Subscription' : 'Manage subscription plans and bundles') %>
         </h1>
     </div>
 

--- a/ecommerce/static/templates/subscription_form.html
+++ b/ecommerce/static/templates/subscription_form.html
@@ -1,52 +1,52 @@
 <div class="row">
     <div class="fields col-md-6">
         <div class="form-group">
-            <label class="hd-4" for="title"><%= gettext('Subscription Title') %> *</label>
-            <input id="title" type="text" class="form-control" name="title" maxlength="255" placeholder="e.g. Subscription of 5 courses for 3 months">
+            <label class="hd-4" for="title"><%= gettext('Plan title') %> *</label>
+            <input id="title" type="text" class="form-control" name="title" maxlength="255" placeholder="For example: One-year subscription">
             <p class="help-block"></p>
         </div>
 
         <div class="form-group">
-            <label class="hd-4" for="description"><%= gettext('Subscription Description') %></label>
-            <textarea id="description" class="form-control" name="description" rows="5" placeholder="e.g. A custom subscription description"></textarea>
+            <label class="hd-4" for="description"><%= gettext('Plan description') %></label>
+            <textarea id="description" class="form-control" name="description" rows="5" placeholder="For example: One-time payment for access to all courses for one year."></textarea>
             <p class="help-block"></p>
         </div>
 
         <div class="form-group">
-            <label class="hd-4" ><%= gettext('Subscription Type') %> *</label>
+            <label class="hd-4" ><%= gettext('Subscription plan type') %> *</label>
             <div class="radio">
                 <label>
                     <input type="radio" name="subscription_type" id="subscriptionTypelimitedAccess" class="non-editable" value="limited-access" checked>
                     <div class="subscription-type-display-name"><%= gettext('Limited Access') %></div>
                     <span id="subscriptionTypelimitedAccessHelpBlock" class="help-block">
-                        <%= gettext('Subscription plan for a limited number of courses for a limited amount of time.') %>
+                        <%= gettext('Access to a predefined number of courses for a custom period of time (example: course bundles with limited-time access)') %>
                     </span>
                 </label>
             </div>
             <div class="radio">
                 <label>
                     <input type="radio" name="subscription_type" id="subscriptionTypeFullAccessCourses" class="non-editable" value="full-access-courses">
-                    <div class="subscription-type-display-name"><%= gettext('Full Access (Courses)') %></div>
+                    <div class="subscription-type-display-name"><%= gettext('Limited time access to all courses') %></div>
                     <span id="subscriptionTypeFullAccessHelpBlock" class="help-block">
-                        <%= gettext('Subscription plan for an unlimited number of courses for a limited amount of time.') %>
+                        <%= gettext('One-time payment for access to all courses for a custom amount of time (for monthly and annual subscription plans)') %>
                     </span>
                 </label>
             </div>
             <div class="radio">
                 <label>
                     <input type="radio" name="subscription_type" id="subscriptionTypeFullAccessTime" class="non-editable" value="full-access-time-period">
-                    <div class="subscription-type-display-name"><%= gettext('Full Access (Time Period)') %></div>
+                    <div class="subscription-type-display-name"><%= gettext('Lifetime access to a limited number of courses') %></div>
                     <span id="subscriptionTypeFullAccessHelpBlock" class="help-block">
-                        <%= gettext('Subscription plan for a limited number of courses for an unlimited amount of time.') %>
+                        <%= gettext('Permanent access to a predefined number of courses (for lifetime access to a limited number of courses)') %>
                     </span>
                 </label>
             </div>
             <div class="radio">
                 <label>
                     <input type="radio" name="subscription_type" id="subscriptionTypeLifetimeAccess" class="non-editable" value="lifetime-access">
-                    <div class="subscription-type-display-name"><%= gettext('Lifetime Access') %></div>
+                    <div class="subscription-type-display-name"><%= gettext('Lifetime Access (All courses)') %></div>
                     <span id="subscriptionTypeLifetimeAccessHelpBlock" class="help-block">
-                        <%= gettext('Subscription plan for an unlimited number of courses for an unlimited amount of time.') %>
+                        <%= gettext('One-time payment for permanent access to all courses (for a full-site access plan)') %>
                     </span>
                 </label>
             </div>
@@ -81,23 +81,23 @@
 
         <div class="seat-price">
             <div class="form-group">
-                <label ><%= gettext('Actual Price in USD') %></label>
+                <label ><%= gettext('Price (USD)') %> *</label>
                 <div class="input-group">
                     <div class="input-group-addon">$</div>
                     <input id="actual-price" class="non-editable" type="number" step="0.01" min="0" class="form-control" name="actual_price" value="0.0">
                 </div>
-                <p class="help-block"><%= gettext('Actual price of the subscription package.') %></p>
+                <p class="help-block"><%= gettext('Price of the subscription plan.') %></p>
             </div>
         </div>
 
         <div class="seat-price">
             <div class="form-group">
-                <label ><%= gettext('Price in USD') %> *</label>
+                <label ><%= gettext('Marked down price (USD)') %></label>
                 <div class="input-group">
                     <div class="input-group-addon">$</div>
                     <input id="price" class="non-editable" type="number" step="0.01" min="0" class="form-control" name="price" value="0.0">
                 </div>
-                <p class="help-block"><%= gettext('Price that the user will pay. (Intended for marketing purposes)') %></p>
+                <p class="help-block"><%= gettext('Price after a discount (if applicable)') %></p>
             </div>
         </div>
 
@@ -106,7 +106,7 @@
             <div class="input-group">
                 <input id="display-order" type="number" step="1" class="form-control" name="display_order" min="1" >
             </div>
-            <p class="help-block"><%= gettext('Display order for the subscription in which learners will see it in the list of subscriptions. (1 being the highest order)') %></p>
+            <p class="help-block"><%= gettext('Display order for the subscription in which learners will see it in the list of subscriptions (1 being the highest order).') %></p>
         </div>
 
         <div class="form-group">

--- a/ecommerce/static/templates/subscription_list.html
+++ b/ecommerce/static/templates/subscription_list.html
@@ -4,7 +4,7 @@
         <div class="pull-right">
             <a href='#' class="btn btn-primary btn-small" name="course-payments" data-toggle="modal"
                 data-target="#coursePaymentsActionModal"></a>
-            <a href="/subscriptions/new/" class="btn btn-primary btn-small"><%- gettext('Add New Subscription') %></a>
+            <a href="/subscriptions/new/" class="btn btn-primary btn-small"><%- gettext('Create a new plan') %></a>
         </div>
     </h1>
 </div>


### PR DESCRIPTION
**Description:** This PR makes text changes based on subscriptions module feedback.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-2549

**Related PR:** [edly-edx-themes/pull/256](https://github.com/edly-io/edly-edx-themes/pull/256)

**Visible Changes:**
`Subscriptions` listing page:
<img width="1371" alt="Screenshot 2021-02-02 at 11 50 15 AM" src="https://user-images.githubusercontent.com/68893403/106563020-fd81e380-654c-11eb-9f32-fb31bc2b38db.png">


`Create New Subscription` page:
<img width="964" alt="Screenshot 2021-02-02 at 11 50 32 AM" src="https://user-images.githubusercontent.com/68893403/106563081-17bbc180-654d-11eb-90b6-8c9e62344a5e.png">
<img width="520" alt="Screenshot 2021-02-02 at 11 50 46 AM" src="https://user-images.githubusercontent.com/68893403/106563110-2013fc80-654d-11eb-9772-80dcfe5bb8cb.png">

