### PR TITLE
Hide credit mode in course modes - EDLY-2634

### DIFF
--- a/ecommerce/static/js/views/course_form_view.js
+++ b/ecommerce/static/js/views/course_form_view.js
@@ -208,6 +208,12 @@ define([
                 this.stickit();
                 this._super();
 
+                if (!window.waffle.SWITCHES['enable_non_edly_cloud_options_switch']) {
+                    const courseTypeCredit = this.$('#courseTypecredit');
+                    courseTypeCredit.attr('disabled', true);
+                    courseTypeCredit.parent().parent().addClass('hidden');
+                }
+
                 return this;
             },
 


### PR DESCRIPTION
**Description:** This PR hides the `Credit` mode in course modes behind `enable_non_edly_cloud_options_switch` waffle switch on the `Create New Course` page.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-2634

**Visible Changes:**
<img width="837" alt="Screenshot 2021-02-22 at 12 27 13 PM" src="https://user-images.githubusercontent.com/68893403/108681589-23c5ee00-7511-11eb-81b6-7761acc4fa59.png">


