### PR TITLE
Removes session auth class from site creation API

### DIFF
--- a/ecommerce/extensions/edly_ecommerce_app/api/v1/views.py
+++ b/ecommerce/extensions/edly_ecommerce_app/api/v1/views.py
@@ -115,7 +115,6 @@ class EdlySiteViewSet(APIView):
     """
     Create Default Payments Site and Site Configuration and Partner.
     """
-    authentication_classes = (SessionAuthentication,)
     permission_classes = [IsAuthenticated, CanAccessSiteCreation]
 
     def post(self, request):


### PR DESCRIPTION
**Description:**
This PR removes the explicit declaration of `SessionAuthentication` as authentication class as the default authentication classes are enough. Also, the method of authentication being used from the panel backend does not work with session auth.