### PR TITLE
Load payment processors config from json string instead of dict

### DIFF
--- a/ecommerce/extensions/edly_ecommerce_app/api/v1/constants.py
+++ b/ecommerce/extensions/edly_ecommerce_app/api/v1/constants.py
@@ -25,7 +25,7 @@ CLIENT_SITE_SETUP_FIELDS = [
     'panel_notification_base_url',
     'contact_mailing_address',
     'theme_dir_name',
-    'oauth_clients'
+    'oauth2_clients'
 ]
 
 EDLY_PANEL_WORKER_USER = 'edly_panel_worker'

--- a/ecommerce/extensions/edly_ecommerce_app/api/v1/tests/test_views.py
+++ b/ecommerce/extensions/edly_ecommerce_app/api/v1/tests/test_views.py
@@ -132,7 +132,7 @@ class EdlySiteViewSet(TestCase):
             colors=dict(primary='#00000'),
             platform_name='Edly',
             theme_dir_name='st-lutherx-ecommerce',
-            oauth_clients={
+            oauth2_clients={
                 'payments-sso': {
                     'id': 'payments-sso-id',
                     'secret': 'payments-sso-secret',

--- a/ecommerce/extensions/edly_ecommerce_app/helpers.py
+++ b/ecommerce/extensions/edly_ecommerce_app/helpers.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
 import jwt
+import json
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
@@ -226,6 +227,6 @@ def get_payment_processors_names(request_data):
     Returns:
         (str): Payment Processors Comma-separated List
     """
-    payment_processors = request_data.get('payment_processor_config', {})
+    payment_processors = json.loads(request_data.get('payment_processor_config', {}))
     edly_slug = request_data.get('edly_slug', '')
     return ','.join(payment_processors.get(edly_slug, {}).keys())

--- a/ecommerce/extensions/edly_ecommerce_app/tests/test_helpers.py
+++ b/ecommerce/extensions/edly_ecommerce_app/tests/test_helpers.py
@@ -51,7 +51,7 @@ class EdlyAppHelperMethodsTests(TestCase):
             colors=dict(primary='#00000'),
             platform_name='Edly',
             theme_dir_name='st-lutherx-ecommerce',
-            oauth_clients={
+            oauth2_clients={
                 'payments-sso': {
                     'id': 'payments-sso-id',
                     'secret': 'payments-sso-secret',


### PR DESCRIPTION
**Description:**  This PR adds implement for load `payment processors config` from JSON string instead of dict

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-3039

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.