### PR TITLE
Load oauth clients from json string instead of dict

### DIFF
--- a/ecommerce/extensions/edly_ecommerce_app/api/v1/views.py
+++ b/ecommerce/extensions/edly_ecommerce_app/api/v1/views.py
@@ -1,6 +1,7 @@
 """
 Views for API v1.
 """
+import json
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.models import Site
@@ -166,7 +167,7 @@ class EdlySiteViewSet(APIView):
         """
         Returns payments SSO and backend OAuth2 values.
         """
-        oauth2_clients = self.request.data.get('oauth2_clients', {})
+        oauth2_clients = json.loads(self.request.data.get('oauth2_clients', {}))
         payments_sso_values = oauth2_clients.get('payments-sso', {})
         payments_backend_values = oauth2_clients.get('payments-backend', {})
         oauth2_values = dict(


### PR DESCRIPTION
**Description:**  This PR loads `OAuth2 Clients` from JSON string instead of dict.

Related PR: https://github.com/edly-io/credentials/pull/9

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-3039

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.