### PR TITLE
Add Subscription order in serializer

### DIFF
--- a/ecommerce/subscriptions/api/v2/serializers.py
+++ b/ecommerce/subscriptions/api/v2/serializers.py
@@ -111,6 +111,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
     subscription_number_of_courses = serializers.SerializerMethodField()
     subscription_duration_value = serializers.SerializerMethodField()
     subscription_duration_unit = serializers.SerializerMethodField()
+    subscription_display_order = serializers.SerializerMethodField()
 
     def get_subscription_type(self, product):
         """
@@ -164,6 +165,12 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             return product.attribute_values.get(attribute__code='subscription_duration_unit').value.option
 
         return None
+
+    def get_subscription_display_order(self, product):
+        """
+        Get subscription display order.
+        """
+        return product.attr.subscription_display_order
 
     def to_internal_value(self, obj):
         """
@@ -336,5 +343,6 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         fields = (
             'id', 'title', 'description', 'date_created', 'date_updated',
             'subscription_type', 'subscription_status', 'subscription_actual_price', 'subscription_price',
-            'subscription_number_of_courses', 'subscription_duration_value', 'subscription_duration_unit'
+            'subscription_number_of_courses', 'subscription_duration_value', 'subscription_duration_unit',
+            'subscription_display_order'
         )

--- a/ecommerce/subscriptions/api/v2/tests/test_serializers.py
+++ b/ecommerce/subscriptions/api/v2/tests/test_serializers.py
@@ -104,6 +104,7 @@ class SubscriptionSerializerTests(SubscriptionProductMixin, TestCase):
             'subscription_actual_price': subscription.attr.subscription_actual_price,
             'subscription_price': subscription.attr.subscription_price,
             'subscription_status': subscription.attr.subscription_status,
+            'subscription_display_order': subscription.attr.subscription_display_order,
         }
         expected_data.update(conditional_attribute_values[subscription_type](subscription))
 


### PR DESCRIPTION
**Description:**
This PR fixes the issue where the subscription order remains `1` after we did edit. It happens because the serilazer doesn't return `subscription_display_order`

**Jira Ticket:**
https://edlyio.atlassian.net/browse/EDLY-3357