### PR TITLE
Theology - Convert Default Currency from USD to GBP

### DIFF
--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -122,7 +122,7 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
-OSCAR_DEFAULT_CURRENCY = 'USD'
+OSCAR_DEFAULT_CURRENCY = 'GBP'
 # END ORDER PROCESSING
 
 

--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -246,12 +246,12 @@ define([
                     disclaimerPrefix;
 
                 // when the price value has a USD prefix, replace it with a $
-                price = price.replace('USD', '$');
+                price = price.replace('GBP', '£');
                 disclaimerPrefix = '* This total contains an approximate conversion. You will be charged ';
 
                 if (BasketPage.isValidLocalCurrencyCookie(countryData) && countryData.countryCode !== 'USA') {
                     $('<span>').attr('class', 'price-disclaimer')
-                        .text(gettext(disclaimerPrefix) + price + ' USD.')
+                        .text(gettext(disclaimerPrefix) + price + ' GBP.')
                         .appendTo('div[aria-labelledby="order-details-region"]');
                 }
             },
@@ -274,7 +274,7 @@ define([
             generateLocalPriceText: function(usdPriceText) {
                 // Assumes price value is prefixed by $ or USD with optional sign followed by optional string
                 var localPriceText = usdPriceText,
-                    prefixMatch = localPriceText.match(/(\$|USD)?(([1-9][0-9]{0,2}(,[0-9]{3})*)|[0-9]+)?\.[0-9]{1,2}/),
+                    prefixMatch = localPriceText.match(/(\£|GBP)?(([1-9][0-9]{0,2}(,[0-9]{3})*)|[0-9]+)?\.[0-9]{1,2}/),
                     entireMatch,
                     groupMatch,
                     startIndex,

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -237,7 +237,7 @@ define([
                     view.$('[name=code_type]').val('enrollment').trigger('change');
                     expect(view.$('.benefit-addon').html()).toBe('%');
                     view.$('[name=benefit_type]').val('Absolute').trigger('change');
-                    expect(view.$('.benefit-addon').html()).toBe('$');
+                    expect(view.$('.benefit-addon').html()).toBe('£');
                 });
 
                 it('should toggle limit on the benefit value input', function() {

--- a/ecommerce/static/js/test/specs/views/course_edit_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_edit_view_spec.js
@@ -179,7 +179,7 @@ define([
                     seat;
 
                 expect($auditElement.length).toBe(1);
-                expect($auditElement.find('.seat-price').text()).toBe('$0.00');
+                expect($auditElement.find('.seat-price').text()).toBe('£0.00');
 
                 expect($verifiedElement.length).toBe(1);
                 expect($verifiedElement.find('[name=price]').val()).toBe('15.00');

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -391,7 +391,7 @@ define([
                 if (val === 'Percentage') {
                     icon = '%';
                 } else if (val === 'Absolute') {
-                    icon = '$';
+                    icon = '£';
                 }
                 return icon;
             },

--- a/ecommerce/static/js/views/offer_view.js
+++ b/ecommerce/static/js/views/offer_view.js
@@ -95,7 +95,7 @@ define([
                 if (benefit.type === 'Percentage') {
                     benefitValue += '%';
                 } else {
-                    benefitValue = '$' + benefitValue;
+                    benefitValue = '£' + benefitValue;
                 }
 
                 course.set({benefit_value: benefitValue});

--- a/ecommerce/static/js/views/subscription_list_view.js
+++ b/ecommerce/static/js/views/subscription_list_view.js
@@ -34,8 +34,8 @@ define([
                     id: subscription.get('id'),
                     title: subscription.get('title'),
                     subscription_type: SubscriptionUtils.formatSubscriptionType(subscription.get('subscription_type')),
-                    subscription_actual_price: subscription.get('subscription_actual_price') + ' USD',
-                    subscription_price: subscription.get('subscription_price') + ' USD',
+                    subscription_actual_price: subscription.get('subscription_actual_price') + ' GBP',
+                    subscription_price: subscription.get('subscription_price') + ' GBP',
                     subscription_status: subscription.get('subscription_status') ? 'Active': 'Inactive',
                     date_created: moment.utc(subscription.get('date_created')).format('MMMM DD, YYYY, h:mm A'),
                     course_payments: subscription.get('course_payments', true)

--- a/ecommerce/static/templates/_course_credit_seats.html
+++ b/ecommerce/static/templates/_course_credit_seats.html
@@ -12,7 +12,7 @@
             <thead>
                 <tr>
                     <th><%= gettext('Credit Provider') %></th>
-                    <th><%= gettext('Price (USD)') %></th>
+                    <th><%= gettext('Price (GBP)') %></th>
                     <th><%= gettext('Credit Hours') %></th>
                     <th><%= gettext('Upgrade Deadline') %></th>
                 </tr>
@@ -21,7 +21,7 @@
                 <% _.each(creditSeats, function (seat) { %>
                     <tr class="course-seat">
                         <td class="seat-credit-provider"><%= seat.get('credit_provider_display_name') %></td>
-                        <td class="seat-price"><%= '$' +  Number(seat.get('price')).toLocaleString() %></td>
+                        <td class="seat-price"><%= '£' +  Number(seat.get('price')).toLocaleString() %></td>
                         <td class="seat-credit-hours"><%= seat.get('credit_hours') %></td>
                         <td class="seat-expires"><% var expires = seat.get('expires');
                             if (expires) {

--- a/ecommerce/static/templates/_course_seat.html
+++ b/ecommerce/static/templates/_course_seat.html
@@ -3,7 +3,7 @@
         <div class="seat-type"><%= seat.getSeatTypeDisplayName() %></div>
     </div>
     <div class="col-sm-4">
-        <div class="seat-price"><%= gettext('Price:') + ' $' + Number(seat.get('price')).toLocaleString() %></div>
+        <div class="seat-price"><%= gettext('Price:') + ' £' + Number(seat.get('price')).toLocaleString() %></div>
         <% var expires = seat.get('expires');
         if(expires) {
         print(gettext('Upgrade Deadline:') + ' ' + moment.utc(expires).format('lll z'));

--- a/ecommerce/static/templates/_offer_course_list.html
+++ b/ecommerce/static/templates/_offer_course_list.html
@@ -52,12 +52,12 @@
                             <% } else { %>
                             <div class="pull-left">
                                 <p class="course-price">
-                                    <span>$<%= course.attributes.stockrecords.price_excl_tax %></span>
+                                    <span>£<%= course.attributes.stockrecords.price_excl_tax %></span>
                                 </p>
                             </div>
                             <div class="pull-left">
                                 <p class="course-new-price">
-                                    <span><%- gettext('Now') %> $<%= course.attributes.new_price %></span>
+                                    <span><%- gettext('Now') %> £<%= course.attributes.new_price %></span>
                                 </p>
                             </div>
                             <% } %>

--- a/ecommerce/static/templates/audit_course_seat_form_field.html
+++ b/ecommerce/static/templates/audit_course_seat_form_field.html
@@ -2,7 +2,7 @@
     <div class="seat-type"><%= gettext('Audit') %></div>
 </div>
 <div class="col-sm-4">
-    <span class="price-label"><%= gettext('Price (in USD)') %>:</span> <span class="seat-price">$0.00</span>
+    <span class="price-label"><%= gettext('Price (in GBP)') %>:</span> <span class="seat-price">£0.00</span>
     <input type="hidden" name="price" value="0">
     <input type="hidden" name="certificate_type">
     <input type="hidden" name="id_verification_required" value="false">

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -69,7 +69,7 @@
                 <input id="benefit-percent" type="radio" class="non-editable" name="benefit_type" value="Percentage">
                 <label for="benefit-percent" class="normal-font-weight"><%= gettext('Percent') %></label>
                 <input id="benefit-fixed" type="radio" class="non-editable" name="benefit_type" value="Absolute">
-                <label for="benefit-fixed" class="normal-font-weight"><%= gettext('Fixed ($USD)') %></label>
+                <label for="benefit-fixed" class="normal-font-weight"><%= gettext('Fixed (£GBP)') %></label>
             </div>
             <p class="help-block"></p>
         </div>
@@ -108,7 +108,7 @@
         <div class="form-group">
             <label for="price"><%= gettext('Invoiced Amount') %> *</label>
             <div class="input-group">
-                <div class="input-group-addon">$</div>
+                <div class="input-group-addon">£</div>
                 <input id="price" type="number" step="0.01" min="0" class="form-control" name="price">
             </div>
             <p class="help-block"></p>
@@ -133,7 +133,7 @@
                 <input id="invoice-discount-percent" type="radio" name="invoice_discount_type" value="Percentage">
                 <label for="invoice-discount-percent" class="normal-font-weight"><%= gettext('Percent') %></label>
                 <input id="invoice-discount-fixed" type="radio" name="invoice_discount_type" value="Absolute">
-                <label for="invoice-discount-fixed" class="normal-font-weight"><%= gettext('Fixed ($USD)') %></label>
+                <label for="invoice-discount-fixed" class="normal-font-weight"><%= gettext('Fixed (£GBP)') %></label>
             </div>
             <p class="help-block"></p>
         </div>

--- a/ecommerce/static/templates/credit_course_seat_form_field.html
+++ b/ecommerce/static/templates/credit_course_seat_form_field.html
@@ -15,7 +15,7 @@
             <thead>
                 <tr>
                     <th id="credit-provider-label"><%= gettext('Credit Provider') %></th>
-                    <th id="price-label"><%= gettext('Price (USD)') %></th>
+                    <th id="price-label"><%= gettext('Price (GBP)') %></th>
                     <th id="credit-hours-label"><%= gettext('Credit Hours') %></th>
                     <th id="expires-label"><%= gettext('Upgrade Deadline') %></th>
                     <th>

--- a/ecommerce/static/templates/credit_course_seat_form_field_row.html
+++ b/ecommerce/static/templates/credit_course_seat_form_field_row.html
@@ -10,7 +10,7 @@
 </td>
 <td class="price">
     <div class="input-group">
-        <div class="input-group-addon">$</div>
+        <div class="input-group-addon">£</div>
         <input type="number" class="form-control" id="price" name="price" aria-labelledby="price-label"
             min="5" step="1" pattern="\d+" value="<%= price %>">
     </div>

--- a/ecommerce/static/templates/enterprise_coupon_detail.html
+++ b/ecommerce/static/templates/enterprise_coupon_detail.html
@@ -95,7 +95,7 @@
                 <% if(coupon.contract_discount_value && coupon.contract_discount_type == 'Percentage') { %>
                     <%= coupon.contract_discount_value %>%
                 <% } else if(coupon.contract_discount_type == 'Absolute') { %>
-                    $<%= coupon.contract_discount_value && coupon.contract_discount_value %>
+                    £<%= coupon.contract_discount_value && coupon.contract_discount_value %>
                 <% } else { %>
                     -
                 <%}%>
@@ -103,7 +103,7 @@
         </div>
         <div class="info-item grid-item prepaid-invoice-amount">
             <div class="heading"><%= gettext('Prepaid Invoice Amount:') %></div>
-            <div class="value">$<%= coupon.prepaid_invoice_amount %></div>
+            <div class="value">£<%= coupon.prepaid_invoice_amount %></div>
         </div>
         <div class="info-item grid-item invoice-type">
             <div class="heading"><%= gettext('Invoice Type:') %></div>

--- a/ecommerce/static/templates/enterprise_coupon_form.html
+++ b/ecommerce/static/templates/enterprise_coupon_form.html
@@ -86,7 +86,7 @@
                 <input id="contract-discount-percent" type="radio" name="contract_discount_type" value="Percentage">
                 <label for="contract-discount-percent" class="normal-font-weight"><%= gettext('Percent') %></label>
                 <input id="contract-discount-fixed" type="radio" name="contract_discount_type" value="Absolute">
-                <label for="contract-discount-fixed" class="normal-font-weight"><%= gettext('Fixed ($USD)') %></label>
+                <label for="contract-discount-fixed" class="normal-font-weight"><%= gettext('Fixed (£GBP)') %></label>
             </div>
             <p class="help-block"></p>
         </div>
@@ -109,7 +109,7 @@
                 <input id="benefit-percent" type="radio" class="non-editable" name="benefit_type" value="Percentage">
                 <label for="benefit-percent" class="normal-font-weight"><%= gettext('Percent') %></label>
                 <input id="benefit-fixed" type="radio" class="non-editable" name="benefit_type" value="Absolute">
-                <label for="benefit-fixed" class="normal-font-weight"><%= gettext('Fixed ($USD)') %></label>
+                <label for="benefit-fixed" class="normal-font-weight"><%= gettext('Fixed (£GBP)') %></label>
             </div>
             <p class="help-block"></p>
         </div>
@@ -142,7 +142,7 @@
         <div class="form-group">
             <label for="price"><%= gettext('Invoiced Amount') %> *</label>
             <div class="input-group">
-                <div class="input-group-addon">$</div>
+                <div class="input-group-addon">£</div>
                 <input id="price" type="number" step="0.01" min="0" class="form-control" name="price">
             </div>
             <p class="help-block"></p>
@@ -167,7 +167,7 @@
                 <input id="invoice-discount-percent" type="radio" name="invoice_discount_type" value="Percentage">
                 <label for="invoice-discount-percent" class="normal-font-weight"><%= gettext('Percent') %></label>
                 <input id="invoice-discount-fixed" type="radio" name="invoice_discount_type" value="Absolute">
-                <label for="invoice-discount-fixed" class="normal-font-weight"><%= gettext('Fixed ($USD)') %></label>
+                <label for="invoice-discount-fixed" class="normal-font-weight"><%= gettext('Fixed (£GBP)') %></label>
             </div>
             <p class="help-block"></p>
         </div>

--- a/ecommerce/static/templates/honor_course_seat_form_field.html
+++ b/ecommerce/static/templates/honor_course_seat_form_field.html
@@ -2,7 +2,7 @@
     <div class="seat-type"><%= gettext('Honor') %></div>
 </div>
 <div class="col-sm-4">
-    <span class="price-label"><%= gettext('Price (in USD)') %>:</span> <span class="seat-price">$0.00</span>
+    <span class="price-label"><%= gettext('Price (in GBP)') %>:</span> <span class="seat-price">£0.00</span>
     <input type="hidden" name="price" value="0">
     <input type="hidden" name="certificate_type" value="honor">
     <input type="hidden" name="id_verification_required" value="false">

--- a/ecommerce/static/templates/professional_course_seat_form_field.html
+++ b/ecommerce/static/templates/professional_course_seat_form_field.html
@@ -6,10 +6,10 @@
 
     <div class="seat-price">
         <div class="form-group">
-            <label for="price"><%= gettext('Price (in USD)') %></label>
+            <label for="price"><%= gettext('Price (in GBP)') %></label>
 
             <div class="input-group">
-                <div class="input-group-addon">$</div>
+                <div class="input-group-addon">£</div>
                 <input type="number" class="form-control" name="price" id="price" min="5" step="1" pattern="\d+"
                        value="<%= price %>">
             </div>

--- a/ecommerce/static/templates/subscription_form.html
+++ b/ecommerce/static/templates/subscription_form.html
@@ -81,9 +81,9 @@
 
         <div class="seat-price">
             <div class="form-group">
-                <label ><%= gettext('Price (USD)') %> *</label>
+                <label ><%= gettext('Price (GBP)') %> *</label>
                 <div class="input-group">
-                    <div class="input-group-addon">$</div>
+                    <div class="input-group-addon">£</div>
                     <input id="actual-price" class="non-editable" type="number" step="0.01" min="0" class="form-control" name="actual_price" value="0.0">
                 </div>
                 <p class="help-block"><%= gettext('Price of the subscription plan.') %></p>
@@ -92,9 +92,9 @@
 
         <div class="seat-price">
             <div class="form-group">
-                <label ><%= gettext('Marked down price (USD)') %></label>
+                <label ><%= gettext('Marked down price (GBP)') %></label>
                 <div class="input-group">
-                    <div class="input-group-addon">$</div>
+                    <div class="input-group-addon">£</div>
                     <input id="price" class="non-editable" type="number" step="0.01" min="0" class="form-control" name="price" value="0.0">
                 </div>
                 <p class="help-block"><%= gettext('Price after a discount (if applicable)') %></p>

--- a/ecommerce/static/templates/verified_course_seat_form_field.html
+++ b/ecommerce/static/templates/verified_course_seat_form_field.html
@@ -7,10 +7,10 @@
 
     <div class="seat-price">
         <div class="form-group">
-            <label for="price"><%= gettext('Price (in USD)') %></label>
+            <label for="price"><%= gettext('Price (in GBP)') %></label>
 
             <div class="input-group">
-                <div class="input-group-addon">$</div>
+                <div class="input-group-addon">£</div>
                 <input type="number" class="form-control" name="price" id="price" min="5" step="1" pattern="\d+"
                        value="<%= price %>">
             </div>

--- a/ecommerce/templates/edx/credit/checkout.html
+++ b/ecommerce/templates/edx/credit/checkout.html
@@ -49,7 +49,7 @@
                                 {% if code %}
                                 <div class="col-sm-2 col-sm-offset-10 price text-left">
                                     <span>{% trans "Price:" as tmsg %}{{ tmsg | force_escape }}</span>
-                                    <span class="pull-right">$<span class="price"></span></span>
+                                    <span class="pull-right">£<span class="price"></span></span>
                                 </div>
                                 <div class="col-sm-2 col-sm-offset-10 discount text-left">
                                     <span>{% trans "Discount:" as tmsg %}{{ tmsg | force_escape }} </span>
@@ -58,7 +58,7 @@
                                 {% endif %}
                                 <div class="col-sm-2 col-sm-offset-10  total-price text-left">
                                     <span>{% trans "Total:" as tmsg %}{{ tmsg | force_escape }} <span>
-                                    <span class="pull-right">$<span class="total-price"></span></span>
+                                    <span class="pull-right">£<span class="total-price"></span></span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
**Description:**  This PR updates code on Ecommerce to add Currency code `GBP` and currency symbol `£` in templates.

_**Note:** This is a temporary fix for `Theology` only since their launch is today on 2 Sep and we are working in parallel on a dynamic fix._

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-3606

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
<img width="1143" alt="Screenshot 2021-09-02 at 6 19 40 PM" src="https://user-images.githubusercontent.com/17013371/131850825-bd81a336-95f2-4843-b2f9-3e0f79c0aadf.png">
