### PR TITLE
Add dynamic currency symbol and code option in subscriptions

### DIFF
--- a/ecommerce/enterprise/forms.py
+++ b/ecommerce/enterprise/forms.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import decimal
 
 from django import forms
+from django.conf import settings
 from django.db.models import Count, Max, Sum
 from django.forms.utils import ErrorList
 from django.utils.translation import ugettext_lazy as _
@@ -54,9 +55,9 @@ class EnterpriseOfferForm(forms.ModelForm):
         help_texts = {
             'end_datetime': '',
             'max_global_applications': _('The maximum number of enrollments that can redeem this offer.'),
-            'max_discount': _('The maximum USD dollar amount that can be redeemed by this offer.'),
+            'max_discount': _('The maximum {currency} amount that can be redeemed by this offer.'.format(currency=settings.OSCAR_DEFAULT_CURRENCY)),
             'max_user_applications': _('The maximum number of enrollments, by a user, that can redeem this offer.'),
-            'max_user_discount': _('The maximum USD dollar amount that can be redeemed using this offer by a user.'),
+            'max_user_discount': _('The maximum {currency} amount that can be redeemed using this offer by a user.'.format(currency=settings.OSCAR_DEFAULT_CURRENCY)),
         }
         labels = {
             'start_datetime': _('Start Date'),

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -11,6 +11,7 @@ import dateutil.parser
 import newrelic.agent
 import six
 import waffle
+from django.conf import settings
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -659,7 +660,7 @@ class PaymentApiLogicMixin(BasketLogicMixin):
         See https://github.com/django-oscar/django-oscar/blob/1.5.4/src/oscar/apps/basket/views.py#L92-L132
         for reference in how this is calculated by django-oscar.
         """
-        shipping_charge = Price('USD', excl_tax=Decimal(0), tax=Decimal(0))
+        shipping_charge = Price(settings.OSCAR_DEFAULT_CURRENCY, excl_tax=Decimal(0), tax=Decimal(0))
         return OrderTotalCalculator().calculate(self.request.basket, shipping_charge)
 
     def _serialize_context(self, context, lines_data):

--- a/ecommerce/static/js/views/subscription_list_view.js
+++ b/ecommerce/static/js/views/subscription_list_view.js
@@ -34,8 +34,8 @@ define([
                     id: subscription.get('id'),
                     title: subscription.get('title'),
                     subscription_type: SubscriptionUtils.formatSubscriptionType(subscription.get('subscription_type')),
-                    subscription_actual_price: subscription.get('subscription_actual_price') + ' USD',
-                    subscription_price: subscription.get('subscription_price') + ' USD',
+                    subscription_actual_price: subscription.get('subscription_actual_price') + ' '+ currency,
+                    subscription_price: subscription.get('subscription_price') + ' '+ currency,
                     subscription_status: subscription.get('subscription_status') ? 'Active': 'Inactive',
                     date_created: moment.utc(subscription.get('date_created')).format('MMMM DD, YYYY, h:mm A'),
                     course_payments: subscription.get('course_payments', true)


### PR DESCRIPTION
**Description:**  This PR adds implement for dynamic currency symbol and code option in Ecommerce subscriptions.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-3616

**Related PR:** https://github.com/edly-io/ecommerce/pull/94

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
![screenshot-dev-payments-multisitesdev-edly-io-subscriptions-new-1631110059172](https://user-images.githubusercontent.com/17013371/132524893-14b23583-ee99-4533-be68-47a0ae9dfcc0.png)