### PR TITLE
Update subscriptions serializers with site's default currency and currency code

### DIFF
--- a/ecommerce/subscriptions/api/v2/serializers.py
+++ b/ecommerce/subscriptions/api/v2/serializers.py
@@ -41,6 +41,8 @@ class SubscriptionListSerializer(serializers.ModelSerializer):
     subscription_type = serializers.SerializerMethodField()
     subscription_actual_price = serializers.SerializerMethodField()
     subscription_price = serializers.SerializerMethodField()
+    subscription_currency = serializers.SerializerMethodField()
+    subscription_currency_code = serializers.SerializerMethodField()
     subscription_status = serializers.SerializerMethodField()
     partner_sku = serializers.SerializerMethodField()
     display_order = serializers.SerializerMethodField()
@@ -69,6 +71,18 @@ class SubscriptionListSerializer(serializers.ModelSerializer):
         Get subscription price for a subscription.
         """
         return product.attr.subscription_price
+
+    def get_subscription_currency(self, product):
+        """
+        Get subscription currency.
+        """
+        return settings.OSCAR_DEFAULT_CURRENCY
+
+    def get_subscription_currency_code(self, product):
+        """
+        Get subscription currency code.
+        """
+        return settings.OSCAR_DEFAULT_CURRENCY_SYMBOL
 
     def get_subscription_status(self, product):
         """
@@ -99,7 +113,8 @@ class SubscriptionListSerializer(serializers.ModelSerializer):
         model = Product
         fields = [
             'id', 'title', 'description', 'date_created', 'subscription_type', 'subscription_actual_price', 'subscription_price',
-            'subscription_status', 'display_order', 'partner_sku', 'is_course_payments_enabled'
+            'subscription_status', 'display_order', 'partner_sku', 'is_course_payments_enabled',
+            'subscription_currency', 'subscription_currency_code',
         ]
 
 
@@ -107,6 +122,8 @@ class SubscriptionSerializer(serializers.ModelSerializer):
     subscription_type = serializers.SerializerMethodField()
     subscription_actual_price = serializers.SerializerMethodField()
     subscription_price = serializers.SerializerMethodField()
+    subscription_currency = serializers.SerializerMethodField()
+    subscription_currency_code = serializers.SerializerMethodField()
     subscription_status = serializers.SerializerMethodField()
     subscription_number_of_courses = serializers.SerializerMethodField()
     subscription_duration_value = serializers.SerializerMethodField()
@@ -130,6 +147,18 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         Get subscription price.
         """
         return product.attr.subscription_price
+
+    def get_subscription_currency(self, product):
+        """
+        Get subscription currency.
+        """
+        return settings.OSCAR_DEFAULT_CURRENCY
+
+    def get_subscription_currency_code(self, product):
+        """
+        Get subscription currency code.
+        """
+        return settings.OSCAR_DEFAULT_CURRENCY_SYMBOL
 
     def get_subscription_status(self, product):
         """
@@ -344,5 +373,5 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             'id', 'title', 'description', 'date_created', 'date_updated',
             'subscription_type', 'subscription_status', 'subscription_actual_price', 'subscription_price',
             'subscription_number_of_courses', 'subscription_duration_value', 'subscription_duration_unit',
-            'subscription_display_order'
+            'subscription_display_order', 'subscription_currency', 'subscription_currency_code',
         )

--- a/ecommerce/subscriptions/api/v2/tests/test_serializers.py
+++ b/ecommerce/subscriptions/api/v2/tests/test_serializers.py
@@ -2,7 +2,7 @@
 Unit tests for subscription API serializers.
 """
 import ddt
-
+from django.conf import settings
 from ecommerce.subscriptions.api.v2.serializers import (
     SubscriptionListSerializer,
     SubscriptionSerializer,
@@ -41,6 +41,8 @@ class SubscriptionListSerializerTests(SubscriptionProductMixin, TestCase):
             'subscription_type': subscription.attr.subscription_type.option,
             'subscription_actual_price': subscription.attr.subscription_actual_price,
             'subscription_price': subscription.attr.subscription_price,
+            'subscription_currency': settings.OSCAR_DEFAULT_CURRENCY,
+            'subscription_currency_code': settings.OSCAR_DEFAULT_CURRENCY_SYMBOL,
             'subscription_status': subscription.attr.subscription_status,
             'display_order': subscription.attr.subscription_display_order,
             'partner_sku': subscription.stockrecords.first().partner_sku,
@@ -103,6 +105,8 @@ class SubscriptionSerializerTests(SubscriptionProductMixin, TestCase):
             'subscription_type': subscription_type,
             'subscription_actual_price': subscription.attr.subscription_actual_price,
             'subscription_price': subscription.attr.subscription_price,
+            'subscription_currency': settings.OSCAR_DEFAULT_CURRENCY,
+            'subscription_currency_code': settings.OSCAR_DEFAULT_CURRENCY_SYMBOL,
             'subscription_status': subscription.attr.subscription_status,
             'subscription_display_order': subscription.attr.subscription_display_order,
         }

--- a/ecommerce/subscriptions/api/v2/tests/test_serializers.py
+++ b/ecommerce/subscriptions/api/v2/tests/test_serializers.py
@@ -3,6 +3,7 @@ Unit tests for subscription API serializers.
 """
 import ddt
 from django.conf import settings
+
 from ecommerce.subscriptions.api.v2.serializers import (
     SubscriptionListSerializer,
     SubscriptionSerializer,
@@ -12,7 +13,6 @@ from ecommerce.subscriptions.api.v2.tests.constants import (
     FULL_ACCESS_TIME_PERIOD,
     LIFETIME_ACCESS,
     LIMITED_ACCESS,
-    SUBSCRIPTION_TYPES,
 )
 from ecommerce.subscriptions.api.v2.tests.mixins import SubscriptionProductMixin
 from ecommerce.tests.testcases import TestCase

--- a/ecommerce/subscriptions/api/v2/tests/test_views.py
+++ b/ecommerce/subscriptions/api/v2/tests/test_views.py
@@ -37,7 +37,7 @@ class SubscriptionViewSetTests(SubscriptionProductMixin, TestCase):
         build renew subscription url for a given subscription.
         """
         return '{root_url}?subscription_id={subscription_id}'.format(
-            root_url=reverse('api:v2:subscriptions-renew-subscription-list'),
+            root_url=reverse('api:v2:subscriptions-renew-subscription'),
             subscription_id=subscription_id
         )
 
@@ -47,8 +47,9 @@ class SubscriptionViewSetTests(SubscriptionProductMixin, TestCase):
         """
         self.create_subscription(stockrecords__partner=self.site.partner)
         expected_keys = [
-            'id', 'title', 'description', 'date_created', 'subscription_type', 'subscription_actual_price', 'subscription_price',
-            'subscription_status', 'display_order', 'partner_sku', 'is_course_payments_enabled'
+            'id', 'title', 'description', 'date_created', 'subscription_type', 'subscription_actual_price',
+            'subscription_price', 'subscription_status', 'display_order', 'partner_sku', 'is_course_payments_enabled',
+            'subscription_currency', 'subscription_currency_code'
         ]
         request_url = reverse('api:v2:subscriptions-list')
         response = self.client.get(request_url)
@@ -90,6 +91,8 @@ class SubscriptionViewSetTests(SubscriptionProductMixin, TestCase):
             'subscription_type': LIMITED_ACCESS,
             'subscription_actual_price': 100.00,
             'subscription_price': 50.00,
+            'subscription_currency': 'USD',
+            'subscription_currency_code': '$',
             'subscription_active_status': 'true',
             'subscription_number_of_courses': 4,
             'subscription_duration_value': 4,
@@ -115,6 +118,8 @@ class SubscriptionViewSetTests(SubscriptionProductMixin, TestCase):
             'subscription_type': LIMITED_ACCESS,
             'subscription_actual_price': 100.00,
             'subscription_price': 50.00,
+            'subscription_currency': 'USD',
+            'subscription_currency_code': '$',
             'subscription_active_status': 'inactive',
             'subscription_number_of_courses': 4,
             'subscription_duration_value': 4,
@@ -134,7 +139,7 @@ class SubscriptionViewSetTests(SubscriptionProductMixin, TestCase):
         """
         Verify that subscriptions API does not toggle course payments flag without authentication.
         """
-        request_url = reverse('api:v2:subscriptions-toggle-course-payments-list')
+        request_url = reverse('api:v2:subscriptions-toggle-course-payments')
         response = self.client.post(request_url)
         self.assertEqual(response.status_code, 401)
 
@@ -143,7 +148,7 @@ class SubscriptionViewSetTests(SubscriptionProductMixin, TestCase):
         Verify that subscriptions API correctly toggles course payments flag with authentication.
         """
         self._login_as_user(is_staff=True)
-        request_url = reverse('api:v2:subscriptions-toggle-course-payments-list')
+        request_url = reverse('api:v2:subscriptions-toggle-course-payments')
         expected_data = {
             'course_payments': not self.site.siteconfiguration.enable_course_payments
         }
@@ -169,7 +174,7 @@ class SubscriptionViewSetTests(SubscriptionProductMixin, TestCase):
         Verify that subscriptions API returns correct response on missing subscription id.
         """
         self._login_as_user(is_staff=True)
-        request_url = reverse('api:v2:subscriptions-renew-subscription-list')
+        request_url = reverse('api:v2:subscriptions-renew-subscription')
 
         expected_data = dict(error='Subscription ID not provided.')
         response = self.client.get(request_url)


### PR DESCRIPTION
**Description:**  This PR updates subscriptions serializers with the site's default currency and currency code.

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-3640
https://edlyio.atlassian.net/browse/EDLY-3616

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
![screenshot-dev-payments-multisitesdev-edly-io-api-v2-subscriptions-1631277101695](https://user-images.githubusercontent.com/17013371/132857628-a0452293-44c3-4473-b562-bc66ee1a3246.png)
