### PR TITLE
Revert middleware changes

### DIFF
--- a/ecommerce/extensions/edly_ecommerce_app/middleware.py
+++ b/ecommerce/extensions/edly_ecommerce_app/middleware.py
@@ -33,11 +33,8 @@ class SettingsOverrideMiddleware(MiddlewareMixin):
             if django_settings_override_values:
                 for config_key, config_value in django_settings_override_values.items():
                     current_value = getattr(settings, config_key, None)
-                    if isinstance(current_value, list) and isinstance(config_value, list):
-                        current_value = current_value.extend(config_value)
-                        setattr(settings, config_key, current_value)
-                    elif isinstance(current_value, tuple) and isinstance(config_value, tuple):
-                        current_value = current_value + config_value
+                    if _should_extend_config(current_value, config_value):
+                        current_value.extend(config_value)
                         setattr(settings, config_key, current_value)
                     else:
                         setattr(settings, config_key, config_value)


### PR DESCRIPTION
**Description:** This PR reverts the changes in middleware because Ecom admin was throwing `Internal Server Error` on saving `site_configuration`.

**Related PR:** https://github.com/edly-io/ecommerce/pull/89/files#diff-d2c300c64f2c4493bc146a9e29da0f6544758d5e699a72ebc7a0c0cbf4d27e0b