### PR TITLE
Fix course_id null when editing coupon issue - EDLY-4262

### DIFF
--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -417,9 +417,6 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         # In case of enterprise, range_data has enterprise data in it as enterprise is defined in UPDATABLE_RANGE_FIELDS
         # so Catalog should not be None if there is an enterprise is associated with it.
         if voucher_range.catalog:
-            if not enterprise_customer_data:
-                range_data['catalog'] = None
-
             if enterprise_customer_data and range_data.get('catalog_query'):
                 range_data['catalog'] = None
 


### PR DESCRIPTION
**Description:** This PR fixes the course id being set to `None` after editing coupon issue. This fix is cherry-picked from eduNEXT PR: https://github.com/eduNEXT/edunext-ecommerce/pull/64

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-4262