### PR TITLE
On coupon edit and publish, always showing null on multiple edits

### DIFF
--- a/ecommerce/static/js/views/coupon_detail_view.js
+++ b/ecommerce/static/js/views/coupon_detail_view.js
@@ -41,7 +41,7 @@ define([
             },
 
             formatLastEditedData: function(lastEdited) {
-                return _s.sprintf('%s - %s', lastEdited[0], this.formatDateTime(lastEdited[1]));
+                return _s.sprintf('%s', this.formatDateTime(lastEdited[1]));
             },
 
             discountValue: function() {


### PR DESCRIPTION
**Description**
The coupon detail shows null value in last edited. The value was edited to show datetime of last edit. 
**JIRA**
https://edlyio.atlassian.net/browse/EDLY-4374

