### PR TITLE
Hide professional track course mode - EDLY-4989

### DIFF
--- a/ecommerce/static/js/views/course_form_view.js
+++ b/ecommerce/static/js/views/course_form_view.js
@@ -218,9 +218,11 @@ define([
                 this._super();
 
                 if (!window.waffle.SWITCHES['enable_non_edly_cloud_options_switch']) {
-                    const courseTypeCredit = this.$('#courseTypecredit');
-                    courseTypeCredit.attr('disabled', true);
-                    courseTypeCredit.parent().parent().addClass('hidden');
+                    const courseTypes = [this.$('#courseTypecredit'), this.$('#courseTypeprofessional')];
+                    courseTypes.forEach(function (courseType, index) {
+                        courseType.attr('disabled', true);
+                        courseType.parent().parent().addClass('hidden');
+                    });
                 }
 
                 return this;


### PR DESCRIPTION
Description: The course mode `professional` in new course creation page is hidden in this PR by use of waffle switch `enable_non_edly_cloud_options_switch` which toggles it's visibility.

JIRA: https://edlyio.atlassian.net/browse/EDLY-4989

Output: When switch is off:

<img width="810" alt="Screenshot 2022-11-25 at 12 31 09 PM" src="https://user-images.githubusercontent.com/109604645/203926244-093cb530-d79c-4aca-bf90-81ad8485a170.png">
