### PR TITLE
Fix authorizenet enrollment issue - EDLY-4936

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -193,8 +193,11 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
             messages if the LMS user id cannot be found.
     """
 
-    def _post_to_enrollment_api(self, data, user, usage):
+    def _post_to_enrollment_api(self, data, user, usage, site=None):
         enrollment_api_url = get_lms_enrollment_api_url()
+        if site:
+            enrollment_api_url = '{}/api/enrollment/v1/enrollment'.format(site.siteconfiguration.lms_url_root)
+            
         timeout = settings.ENROLLMENT_FULFILLMENT_TIMEOUT
         headers = {
             'Content-Type': 'application/json',
@@ -423,7 +426,7 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
 
                 # Post to the Enrollment API. The LMS will take care of posting a new EnterpriseCourseEnrollment to
                 # the Enterprise service if the user+course has a corresponding EnterpriseCustomerUser.
-                response = self._post_to_enrollment_api(data, user=order.user, usage='fulfill enrollment')
+                response = self._post_to_enrollment_api(data, user=order.user, usage='fulfill enrollment', site=order.site)
 
                 if response.status_code == status.HTTP_200_OK:
                     line.set_status(LINE.COMPLETE)


### PR DESCRIPTION
Description: This PR resolves the issue of courses not enrolling after payment through authorizenet. It does so by explicitly using the on-to-one field on site object passed through order to get it’s siteconfiguration object and subsequently the value of the desired lms_url_root

JIRA: Link to ticket: https://edlyio.atlassian.net/browse/EDLY-4936