### PR TITLE
Fixed sorting for actual price and price columns in subscriptions tab

### DIFF
--- a/ecommerce/static/js/views/subscription_list_view.js
+++ b/ecommerce/static/js/views/subscription_list_view.js
@@ -19,6 +19,19 @@ define([
               confirmationDialog) {
         'use strict';
 
+         // Custom sorting plugin for currency values
+         $.extend($.fn.dataTableExt.oSort, {
+            "currency-pre": function(value) {
+                return parseFloat(value.replace(/[^\d.-]/g, '')) || 0;
+            },
+            "currency-asc": function(a, b) {
+                return a - b;
+            },
+            "currency-desc": function(a, b) {
+                return b - a;
+            }
+        });
+
         return Backbone.View.extend({
             className: 'subscription-list-view',
 
@@ -83,10 +96,12 @@ define([
                             {
                                 title: gettext('Actual Price'),
                                 data: 'subscription_actual_price',
+                                type: 'currency'
                             },
                             {
                                 title: gettext('Price'),
                                 data: 'subscription_price',
+                                type: 'currency'
                             },
                             {
                                 title: gettext('Active Status'),


### PR DESCRIPTION
### Description:
This pull request addresses an issue with the incorrect sorting of the `Actual Price` and `Price` columns in the Subscriptions tab. The problem arose because DataTables was performing lexicographical sorting instead of numerical sorting, due to an incorrect data type registration for these columns. To resolve this, custom sorting logic has been implemented to ensure accurate numerical sorting.

JIRA: https://edlyio.atlassian.net/browse/EDLY-7141

### Testing Instructions:
1. Sign in to the e-commerce platform.
2. Navigate to the `Subscriptions and Bundles` tab.
3. Test the sorting functionality by clicking the sort buttons on the `Actual Price` and `Price` columns.
4. Verify that the columns now sort correctly in ascending and descending order.

### Screenshot after fix:
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/2b16b4b0-83da-46b6-858a-76cc74471c7d">
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/569b3853-e08d-4fb2-8b5e-7c317c012c10">

