### PR TITLE
fix: remove bank account option from payment form

### DIFF
--- a/ecommerce/extensions/payment/processors/authorizenet.py
+++ b/ecommerce/extensions/payment/processors/authorizenet.py
@@ -89,9 +89,14 @@ class AuthorizeNet(BaseClientSidePaymentProcessor):
         }
         payment_return_setting.settingValue = json.dumps(payment_return_configrations)
 
+        payment_options_setting = apicontractsv1.settingType()
+        payment_options_setting.settingName = apicontractsv1.settingNameEnum.hostedPaymentPaymentOptions
+        payment_options_setting.settingValue = json.dumps({"showBankAccount": False})
+
         settings = apicontractsv1.ArrayOfSetting()
         settings.setting.append(payment_button_setting)
         settings.setting.append(payment_return_setting)
+        settings.setting.append(payment_options_setting)
         return settings
 
     def get_authorizenet_lineitems(self, basket):


### PR DESCRIPTION
## Description
This PR updates the Authorize.net flow to remove the Bank account payment option

## Ticket
https://projects.arbisoft.com/project/edly-product/task/7076

## Docs
https://developer.authorize.net/api/reference/features/accept-hosted.html#:~:text=shade%20of%20blue.-,hostedPaymentPaymentOptions,-%7B%22cardCodeRequired%22%3A%20false%2C%20%22showCreditCard