### PR TITLE
Redirect user to contact us page, if payment support url present.

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -579,6 +579,7 @@ class BasketSummaryView(BasketLogicMixin, BasketView):
         context.update({
             'formset_lines_data': list(zip(formset, lines_data)),
             'homepage_url': get_lms_url(''),
+            'support_url': site_configuration.payment_support_url or get_lms_url(),
             'min_seat_quantity': 1,
             'max_seat_quantity': 100,
             'payment_processors': payment_processors,


### PR DESCRIPTION
This PR fixes the redirect issue in the contact us text. It check, if a support URL is available in site configuration and redirect the user to that page. 

