### PR TITLE
Changed messages storage to session to avoid them from stacking up

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -626,6 +626,8 @@ LANGUAGE_COOKIE_NAME = 'openedx-language-preference'
 SESSION_COOKIE_SECURE = False
 # END COOKIE CONFIGURATION
 
+# Messages
+MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 
 # CELERY
 # Default broker URL. See http://celery.readthedocs.io/en/latest/userguide/configuration.html#broker-url.


### PR DESCRIPTION
**Description**:
This PR changes the messages storage from default cookies to sessions to make them avoid from stacking up.

**Ticket**:
https://projects.arbisoft.com/project/edly-product/task/7134
