### PR TITLE
Fix/update django haystack

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,7 +44,7 @@ django-filter==2.4.0      # via -r requirements/base.in
 django-haystack==3.1.0    # via django-oscar
 django-libsass==0.8       # via -r requirements/base.in
 django-model-utils==4.0.0  # via edx-rbac
-git+https://github.com/edly-io/django-oscar.git@7e9680955091f0349b4c312852c607ae67104416
+git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
 django-phonenumber-field==2.0.1  # via django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.12.0  # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,7 +44,7 @@ django-filter==2.4.0      # via -r requirements/base.in
 django-haystack==3.1.0    # via django-oscar
 django-libsass==0.8       # via -r requirements/base.in
 django-model-utils==4.0.0  # via edx-rbac
-git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
+git+https://github.com/edly-io/django-oscar.git@7e9680955091f0349b4c312852c607ae67104416
 django-phonenumber-field==2.0.1  # via django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.12.0  # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,10 +41,10 @@ django-crum==0.7.8        # via edx-django-utils, edx-rbac
 django-extensions==3.0.9  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
 django-filter==2.4.0      # via -r requirements/base.in
-django-haystack==2.8.1    # via django-oscar
+django-haystack==3.1.0    # via django-oscar
 django-libsass==0.8       # via -r requirements/base.in
 django-model-utils==4.0.0  # via edx-rbac
-django-oscar==2.0.4       # via -c requirements/pins.txt, -r requirements/base.in
+git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
 django-phonenumber-field==2.0.1  # via django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.12.0  # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -51,7 +51,7 @@ django-filter==2.4.0      # via -r requirements/test.txt
 django-haystack==3.1.0      # via -r requirements/test.txt, django-oscar
 django-libsass==0.8       # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-rbac
-git+https://github.com/edly-io/django-oscar.git@7e9680955091f0349b4c312852c607ae67104416
+git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
 django-phonenumber-field==2.0.1  # via -r requirements/test.txt, django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.12.0  # via -r requirements/test.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -51,7 +51,7 @@ django-filter==2.4.0      # via -r requirements/test.txt
 django-haystack==3.1.0      # via -r requirements/test.txt, django-oscar
 django-libsass==0.8       # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-rbac
-git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
+git+https://github.com/edly-io/django-oscar.git@7e9680955091f0349b4c312852c607ae67104416
 django-phonenumber-field==2.0.1  # via -r requirements/test.txt, django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.12.0  # via -r requirements/test.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -48,10 +48,10 @@ django-debug-toolbar==3.1.1  # via -r requirements/dev.in
 django-extensions==3.0.9  # via -r requirements/test.txt
 django-extra-views==0.11.0  # via -r requirements/test.txt, django-oscar
 django-filter==2.4.0      # via -r requirements/test.txt
-django-haystack==2.8.1    # via -r requirements/test.txt, django-oscar
+django-haystack==3.1.0      # via -r requirements/test.txt, django-oscar
 django-libsass==0.8       # via -r requirements/test.txt
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-rbac
-django-oscar==2.0.4       # via -r requirements/test.txt
+git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
 django-phonenumber-field==2.0.1  # via -r requirements/test.txt, django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.12.0  # via -r requirements/test.txt

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -9,7 +9,7 @@
 # linking to it here is good.
 
 # Newer version introduces `No installed app with label 'communication'.`
-django-oscar<2.1
+django-oscar==2.0.4
 
 # causing tests failures
 httpretty==0.9.7

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -8,6 +8,9 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
+# Newer version introduces `No installed app with label 'communication'.`
+django-oscar<2.1
+
 # causing tests failures
 httpretty==0.9.7
 

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -8,9 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Newer version introduces `No installed app with label 'communication'.`
-django-oscar==2.0.4
-
 # causing tests failures
 httpretty==0.9.7
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -46,7 +46,7 @@ django-filter==2.4.0      # via -r requirements/base.in
 django-haystack==3.1.0      # via django-oscar
 django-libsass==0.8       # via -r requirements/base.in
 django-model-utils==4.0.0  # via edx-rbac
-git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
+git+https://github.com/edly-io/django-oscar.git@7e9680955091f0349b4c312852c607ae67104416
 django-phonenumber-field==2.0.1  # via django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-ses==1.0.3         # via -r requirements/production.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -43,10 +43,10 @@ django-crum==0.7.8        # via edx-django-utils, edx-rbac
 django-extensions==3.0.9  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
 django-filter==2.4.0      # via -r requirements/base.in
-django-haystack==2.8.1    # via django-oscar
+django-haystack==3.1.0      # via django-oscar
 django-libsass==0.8       # via -r requirements/base.in
 django-model-utils==4.0.0  # via edx-rbac
-django-oscar==2.0.4       # via -c requirements/pins.txt, -r requirements/base.in
+git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
 django-phonenumber-field==2.0.1  # via django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-ses==1.0.3         # via -r requirements/production.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -46,7 +46,7 @@ django-filter==2.4.0      # via -r requirements/base.in
 django-haystack==3.1.0      # via django-oscar
 django-libsass==0.8       # via -r requirements/base.in
 django-model-utils==4.0.0  # via edx-rbac
-git+https://github.com/edly-io/django-oscar.git@7e9680955091f0349b4c312852c607ae67104416
+git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
 django-phonenumber-field==2.0.1  # via django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-ses==1.0.3         # via -r requirements/production.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -49,7 +49,7 @@ django-filter==2.4.0      # via -r requirements/base.txt
 django-haystack==3.1.0      # via -r requirements/base.txt, django-oscar
 django-libsass==0.8       # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
-git+https://github.com/edly-io/django-oscar.git@7e9680955091f0349b4c312852c607ae67104416
+git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
 django-phonenumber-field==2.0.1  # via -r requirements/base.txt, django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.12.0  # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -46,10 +46,10 @@ django-crum==0.7.8        # via -r requirements/base.txt, -r requirements/e2e.tx
 django-extensions==3.0.9  # via -r requirements/base.txt
 django-extra-views==0.11.0  # via -r requirements/base.txt, django-oscar
 django-filter==2.4.0      # via -r requirements/base.txt
-django-haystack==2.8.1    # via -r requirements/base.txt, django-oscar
+django-haystack==3.1.0      # via -r requirements/base.txt, django-oscar
 django-libsass==0.8       # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
-django-oscar==2.0.4       # via -c requirements/pins.txt, -r requirements/base.txt
+git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
 django-phonenumber-field==2.0.1  # via -r requirements/base.txt, django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.12.0  # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -49,7 +49,7 @@ django-filter==2.4.0      # via -r requirements/base.txt
 django-haystack==3.1.0      # via -r requirements/base.txt, django-oscar
 django-libsass==0.8       # via -r requirements/base.txt
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
-git+https://github.com/edly-io/django-oscar.git@v2.0.4#egg=django-oscar==v2.0.4
+git+https://github.com/edly-io/django-oscar.git@7e9680955091f0349b4c312852c607ae67104416
 django-phonenumber-field==2.0.1  # via -r requirements/base.txt, django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.12.0  # via -r requirements/base.txt


### PR DESCRIPTION
**Description:** This PR bumps `django-haystack` version to `3.1.0` as `2.8.1` version was not compatible anymore. Also, loosened `django-oscar` dependency for `django-haystack` by forking `django-oscar` and making the required changes.
