### PR TITLE
Fix: handle reporting error on program coupon flow.

### DIFF
--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -50,7 +50,9 @@ VoucherOffer = get_model('voucher', 'Voucher_offers')
 
 
 def _add_redemption_course_ids(new_row_to_append, header_row, redemption_course_ids):
-    if any(row in [_('Catalog Query'), _('Program UUID')] for row in header_row):
+    # Only add redemption course columns for Catalog Query coupons; Program UUID and
+    # regular course coupons do not include these columns in the report.
+    if _('Catalog Query') in header_row:
         if len(redemption_course_ids) > 1:
             new_row_to_append[_('Redeemed For Course IDs')] = ', '.join(redemption_course_ids)
         else:


### PR DESCRIPTION
## Description: 
Wrote a fix for program coupon report generation error. 



```
=> /edx/var/log/nginx/access.log <==
110.39.173.34 - 10.0.1.197 - - https [04/Feb/2026:04:54:13 +0000]  "GET /api/v2/coupons/coupon_reports/330 HTTP/1.1" 301 0 0.022 "https://payments.theologyx.com/coupons/330/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
==> /edx/var/log/supervisor/ecommerce-stderr.log <==
[2026-02-04 04:54:13 +0000] [2232566] [INFO] GET /api/v2/coupons/coupon_reports/330/
[2026-02-04 04:54:15 +0000] [2232566] [ERROR] Error handling request /api/v2/coupons/coupon_reports/330/
Traceback (most recent call last):
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 544, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
    return bound_method(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/contrib/auth/decorators.py", line 21, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/edly_ecommerce_app/api/v1/views.py", line 112, in dispatch
    return super(StaffOrCourseCreatorOnlyMixin, self).dispatch(request, *args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 940, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/views/generic/base.py", line 97, in dispatch
    return handler(request, *args, **kwargs)
  File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/voucher/views.py", line 48, in get
    writer.writerow(row)
  File "/usr/lib/python3.8/csv.py", line 154, in writerow
    return self.writer.writerow(self._dict_to_list(rowdict))
  File "/usr/lib/python3.8/csv.py", line 149, in _dict_to_list
    raise ValueError("dict contains fields not in fieldnames: "
ValueError: dict contains fields not in fieldnames: 'Redeemed For Course ID'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/crum/__init__.py", line 97, in __call__
    response = self.get_response(request)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 1203, in _wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/exception.py", line 36, in inner
    response = response_for_exception(request, exc)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/exception.py", line 90, in response_for_exception
    response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 490, in wrapper
    return _wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 483, in _wrapped
    return wrapped(request, resolver, exc_info)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/exception.py", line 129, in handle_uncaught_exception
    return callback(request, **param_dict)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 544, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/utils/decorators.py", line 142, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/views/defaults.py", line 80, in server_error
    return HttpResponseServerError(template.render())
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/backends/django.py", line 61, in render
    return self.template.render(context)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/base.py", line 171, in render
    return self._render(context)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 121, in dynamic_wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/base.py", line 163, in _render
    return self.nodelist.render(context)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/base.py", line 937, in render
    bit = node.render_annotated(context)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/base.py", line 904, in render_annotated
    return self.render(context)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/loader_tags.py", line 150, in render
    return compiled_parent._render(context)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/api/function_trace.py", line 121, in dynamic_wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/base.py", line 163, in _render
    return self.nodelist.render(context)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/base.py", line 937, in render
    bit = node.render_annotated(context)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/base.py", line 904, in render_annotated
    return self.render(context)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/waffle/templatetags/waffle_tags.py", line 83, in render
    return _generate_waffle_js(context['request'])
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/template/context.py", line 83, in __getitem__
    raise KeyError(key)
KeyError: 'request'
```