### PR TITLE
feat: add MyFatoorah payment processor (PCI DSS SAQ A hosted redirect)

### DIFF
--- a/ecommerce/extensions/payment/migrations/0034_create_myfatoorah_switch.py
+++ b/ecommerce/extensions/payment/migrations/0034_create_myfatoorah_switch.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from django.conf import settings
+from django.db import migrations
+
+from ecommerce.extensions.payment.processors.myfatoorah import MyFatoorah
+
+
+def create_switch(apps, schema_editor):
+    """ Create the switch that gates the MyFatoorah processor.
+
+    Created inactive: MyFatoorah is only for tenants that have credentials, so it
+    should be switched on deliberately rather than appearing everywhere on deploy.
+    """
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.get_or_create(
+        name=settings.PAYMENT_PROCESSOR_SWITCH_PREFIX + MyFatoorah.NAME,
+        defaults={'active': False},
+    )
+
+
+def delete_switch(apps, schema_editor):
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name=settings.PAYMENT_PROCESSOR_SWITCH_PREFIX + MyFatoorah.NAME).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('payment', '0033_merge_20250114_0556'),
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_switch, delete_switch)
+    ]

--- a/ecommerce/extensions/payment/processors/myfatoorah.py
+++ b/ecommerce/extensions/payment/processors/myfatoorah.py
@@ -1,0 +1,525 @@
+""" MyFatoorah payment processor.
+
+MyFatoorah is a MENA payment gateway (KNET, mada, Visa/Mastercard, Benefit,
+Apple Pay) used across KW, SA, AE, QA, BH, JO, OM and EG.
+
+PCI DSS scope
+-------------
+This processor never touches cardholder data. The learner is redirected to
+MyFatoorah's own hosted invoice page, where every card field lives, and comes
+back to us with nothing but an opaque ``paymentId``. That is what keeps Edly
+eligible for SAQ A rather than SAQ A-EP or SAQ D.
+
+Four properties have to survive any future edit to this file:
+
+* Subclass ``BasePaymentProcessor``, never ``BaseClientSidePaymentProcessor``.
+  The latter introduces a ``payment/myfatoorah.html`` template, which is exactly
+  where a card input would eventually be added.
+* Never call MyFatoorah's ``DirectPayment`` endpoint. Their own documentation
+  gates it on the caller already being PCI certified.
+* Never trust the browser about whether a payment succeeded. ``get_payment_status``
+  re-asks MyFatoorah server-to-server, and that answer is the only one used.
+* Never persist or log a PAN, CVV or expiry beyond the masked values MyFatoorah
+  returns. ``_scrub`` enforces the allow-list of fields we are willing to store.
+"""
+
+
+import base64
+import hashlib
+import hmac
+import logging
+from decimal import Decimal
+
+import requests
+from django.urls import reverse
+from oscar.apps.payment.exceptions import GatewayError
+from six.moves.urllib.parse import urljoin
+
+from ecommerce.core.url_utils import get_ecommerce_url
+from ecommerce.extensions.payment.exceptions import MissingTransactionDetailError
+from ecommerce.extensions.payment.processors import BasePaymentProcessor, HandledProcessorResponse
+
+logger = logging.getLogger(__name__)
+
+SEND_PAYMENT_ENDPOINT = '/v2/SendPayment'
+GET_PAYMENT_STATUS_ENDPOINT = '/v2/GetPaymentStatus'
+
+# Invoice-level state. MyFatoorah returns exactly one of Pending/Paid/Canceled.
+INVOICE_STATUS_PAID = 'Paid'
+
+# Transaction-level state. 'Succss' is MyFatoorah's own spelling in their API
+# contract, not a typo here -- see their GetPaymentStatus reference.
+TRANSACTION_STATUS_SUCCESS = 'Succss'
+
+# Webhook V2 event codes.
+EVENT_PAYMENT_STATUS_CHANGED = 1
+
+DEFAULT_TIMEOUT = 15
+
+# Fields we are willing to write to PaymentProcessorResponse. Everything else in
+# a MyFatoorah payload is dropped before it is persisted. Both spellings of the
+# transaction-value field are listed because MyFatoorah ships the misspelled one.
+_DATA_FIELDS = (
+    'InvoiceId',
+    'InvoiceStatus',
+    'InvoiceReference',
+    'CustomerReference',
+    'InvoiceValue',
+    'InvoiceDisplayValue',
+    'CreatedDate',
+    'ExpiryDate',
+)
+_TRANSACTION_FIELDS = (
+    'TransactionDate',
+    'TransactionStatus',
+    'PaymentId',
+    'PaymentGateway',
+    'AuthorizationId',
+    'ReferenceId',
+    'TrackId',
+    'TransactionValue',
+    'TransationValue',
+    'PaidCurrency',
+    'PaidCurrencyValue',
+    'Error',
+    'ErrorCode',
+)
+# Masked PAN and brand only. No cardholder name, no expiry, and there is never a
+# CVV to begin with.
+_CARD_FIELDS = (
+    'Number',
+    'Brand',
+)
+
+
+def _scrub(payload):
+    """
+    Reduce a MyFatoorah payload to the fields we are willing to store.
+
+    ``record_processor_response`` persists whatever it is handed, forever. A
+    GetPaymentStatus response carries a ``Card`` object including the cardholder
+    name and expiry, so this filters down to an allow-list rather than trusting
+    the gateway not to widen its payload later.
+
+    Arguments:
+        payload (dict): Raw response body from MyFatoorah.
+
+    Returns:
+        dict: A copy safe to persist.
+    """
+    if not isinstance(payload, dict):
+        return {}
+
+    data = payload.get('Data')
+    scrubbed_data = None
+    if isinstance(data, dict):
+        scrubbed_data = {key: data[key] for key in _DATA_FIELDS if key in data}
+
+        transactions = []
+        for transaction in data.get('InvoiceTransactions') or []:
+            if not isinstance(transaction, dict):
+                continue
+            scrubbed_transaction = {
+                key: transaction[key] for key in _TRANSACTION_FIELDS if key in transaction
+            }
+            card = transaction.get('Card')
+            if isinstance(card, dict):
+                scrubbed_transaction['Card'] = {key: card[key] for key in _CARD_FIELDS if key in card}
+            # Older MyFatoorah payloads put the masked PAN directly on the transaction.
+            if 'CardNumber' in transaction:
+                scrubbed_transaction['CardNumber'] = transaction['CardNumber']
+            transactions.append(scrubbed_transaction)
+        if transactions:
+            scrubbed_data['InvoiceTransactions'] = transactions
+
+        if 'InvoiceURL' in data:
+            scrubbed_data['InvoiceURL'] = data['InvoiceURL']
+
+    scrubbed = {key: payload[key] for key in ('IsSuccess', 'Message') if key in payload}
+    if payload.get('ValidationErrors'):
+        scrubbed['ValidationErrors'] = payload['ValidationErrors']
+    if scrubbed_data is not None:
+        scrubbed['Data'] = scrubbed_data
+    return scrubbed
+
+
+class MyFatoorah(BasePaymentProcessor):
+    """
+    MyFatoorah hosted-redirect payment processor.
+
+    Deliberately declares no ``template_name`` and leaves ``client_side_payment_url``
+    at its inherited ``None``. That absence is a PCI control, not an oversight.
+    """
+
+    NAME = 'myfatoorah'
+
+    def __init__(self, site):
+        """
+        Constructs a new instance of the MyFatoorah processor.
+
+        Raises:
+            KeyError: If a required setting is not configured for this payment processor.
+        """
+        super(MyFatoorah, self).__init__(site)
+        configuration = self.configuration
+        self.api_token = configuration['api_token']
+        self.base_url = configuration['base_url']
+        # Optional, but signature verification fails closed without it.
+        self.webhook_secret = configuration.get('webhook_secret')
+        self.timeout = configuration.get('timeout', DEFAULT_TIMEOUT)
+
+    @property
+    def cancel_url(self):
+        return get_ecommerce_url(self.configuration['cancel_checkout_path'])
+
+    @property
+    def error_url(self):
+        return get_ecommerce_url(self.configuration['error_path'])
+
+    @property
+    def callback_url(self):
+        """ The URL MyFatoorah returns the learner to once they leave the hosted page. """
+        return get_ecommerce_url(reverse('myfatoorah:callback'))
+
+    @property
+    def _headers(self):
+        return {
+            'Authorization': 'Bearer {token}'.format(token=self.api_token),
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        }
+
+    def _request(self, endpoint, payload, basket=None):
+        """
+        POST to MyFatoorah and return the parsed body.
+
+        Failures are recorded for audit and re-raised as ``GatewayError``. Note that
+        neither the request headers nor the raw response body are logged: the former
+        carries the API token and the latter can carry masked card data.
+
+        Arguments:
+            endpoint (str): Path on the MyFatoorah API, e.g. ``/v2/SendPayment``.
+            payload (dict): JSON request body.
+
+        Keyword Arguments:
+            basket (Basket): Basket to associate with any recorded response.
+
+        Returns:
+            dict: Parsed response body.
+
+        Raises:
+            GatewayError: On transport failure, unparseable body, or ``IsSuccess: false``.
+        """
+        url = urljoin(self.base_url, endpoint)
+
+        try:
+            response = requests.post(url, json=payload, headers=self._headers, timeout=self.timeout)
+        except requests.RequestException as exc:
+            logger.error(
+                'MyFatoorah request to [%s] failed with [%s].', endpoint, type(exc).__name__
+            )
+            raise GatewayError('MyFatoorah request to {} failed.'.format(endpoint))
+
+        try:
+            body = response.json()
+        except ValueError:
+            logger.error(
+                'MyFatoorah returned a non-JSON response from [%s] with status [%d].',
+                endpoint,
+                response.status_code,
+            )
+            raise GatewayError('MyFatoorah returned an unparseable response from {}.'.format(endpoint))
+
+        if not body.get('IsSuccess'):
+            self.record_processor_response(_scrub(body), basket=basket)
+            logger.error(
+                'MyFatoorah rejected the request to [%s] with status [%d]: %s',
+                endpoint,
+                response.status_code,
+                body.get('Message'),
+            )
+            raise GatewayError('MyFatoorah rejected the request to {}.'.format(endpoint))
+
+        return body
+
+    def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
+        """
+        Create a MyFatoorah invoice and hand back its hosted payment page.
+
+        The learner is sent to MyFatoorah's own page, which renders both the
+        payment-method picker and the card form, so no card data ever reaches us.
+
+        Arguments:
+            basket (Basket): The basket of products being purchased.
+
+        Keyword Arguments:
+            request (Request): Unused; accepted to satisfy the base class contract.
+            use_client_side_checkout (bool): Unused; this processor is redirect-only.
+
+        Returns:
+            dict: Contains ``payment_page_url``, the MyFatoorah hosted invoice URL.
+
+        Raises:
+            GatewayError: If MyFatoorah declines to create the invoice.
+        """
+        owner = basket.owner
+        payload = {
+            'InvoiceValue': float(basket.total_incl_tax),
+            'DisplayCurrencyIso': basket.currency,
+            'CustomerName': owner.get_full_name() or owner.username,
+            'CustomerEmail': owner.email,
+            # Our end of the correlation. MyFatoorah echoes this back on status
+            # lookups and webhooks, letting us tie a payment to a basket.
+            'CustomerReference': basket.order_number,
+            # 'LNK' asks MyFatoorah for an invoice link instead of emailing or
+            # texting the learner -- we redirect them to it ourselves.
+            'NotificationOption': 'LNK',
+            'CallBackUrl': self.callback_url,
+            'ErrorUrl': self.callback_url,
+        }
+
+        body = self._request(SEND_PAYMENT_ENDPOINT, payload, basket=basket)
+        data = body.get('Data') or {}
+        invoice_id = data.get('InvoiceId')
+        invoice_url = data.get('InvoiceURL')
+
+        if not invoice_id or not invoice_url:
+            self.record_processor_response(_scrub(body), basket=basket)
+            logger.error(
+                'MyFatoorah accepted the invoice for basket [%d] but returned no InvoiceId/InvoiceURL.',
+                basket.id,
+            )
+            raise GatewayError('MyFatoorah did not return a payment URL.')
+
+        # This row is how the callback and webhook find their way back to the
+        # basket, so it has to be written before the learner leaves.
+        self.record_processor_response(_scrub(body), transaction_id=invoice_id, basket=basket)
+        logger.info(
+            'Created MyFatoorah invoice [%s] for basket [%d].', invoice_id, basket.id
+        )
+
+        return {'payment_page_url': invoice_url}
+
+    def get_payment_status(self, key, key_type='PaymentId', basket=None):
+        """
+        Ask MyFatoorah, server-to-server, what actually happened to a payment.
+
+        This is the only authority on payment state. The query string MyFatoorah
+        redirects the learner back with, and the body it posts to our webhook, are
+        both treated as untrusted lookup keys that lead here.
+
+        Arguments:
+            key (str): The ``paymentId`` or ``InvoiceId`` to look up.
+
+        Keyword Arguments:
+            key_type (str): Which identifier ``key`` is -- ``PaymentId`` (MyFatoorah's
+                recommendation) or ``InvoiceId``.
+            basket (Basket): Basket to associate with any recorded response.
+
+        Returns:
+            dict: The parsed GetPaymentStatus response body.
+
+        Raises:
+            MissingTransactionDetailError: If MyFatoorah returns no invoice data.
+            GatewayError: On transport or gateway failure.
+        """
+        body = self._request(
+            GET_PAYMENT_STATUS_ENDPOINT,
+            {'Key': str(key), 'KeyType': key_type},
+            basket=basket,
+        )
+
+        if not (body.get('Data') or {}).get('InvoiceId'):
+            logger.error('MyFatoorah returned no invoice detail for %s [%s].', key_type, key)
+            raise MissingTransactionDetailError(
+                'MyFatoorah returned no invoice detail for {} {}.'.format(key_type, key)
+            )
+
+        return body
+
+    def record_status_response(self, status_response, basket=None):
+        """
+        Persist a scrubbed status response for audit without treating it as a payment.
+
+        Used when we look up a payment and decide *not* to act on it, so the decision
+        is still traceable afterwards.
+
+        Arguments:
+            status_response (dict): A GetPaymentStatus response body.
+
+        Keyword Arguments:
+            basket (Basket): Basket to associate with the recorded response.
+
+        Returns:
+            PaymentProcessorResponse
+        """
+        data = status_response.get('Data') or {}
+        return self.record_processor_response(
+            _scrub(status_response), transaction_id=data.get('InvoiceId'), basket=basket
+        )
+
+    @staticmethod
+    def is_paid(status_response):
+        """
+        Return True only if MyFatoorah considers this invoice settled.
+
+        Both the invoice and at least one of its transactions must agree, so a
+        pending or failed attempt against a paid-looking invoice cannot slip past.
+
+        Arguments:
+            status_response (dict): A GetPaymentStatus response body.
+
+        Returns:
+            bool
+        """
+        data = status_response.get('Data') or {}
+        if data.get('InvoiceStatus') != INVOICE_STATUS_PAID:
+            return False
+
+        transactions = data.get('InvoiceTransactions') or []
+        return any(
+            transaction.get('TransactionStatus') == TRANSACTION_STATUS_SUCCESS
+            for transaction in transactions
+            if isinstance(transaction, dict)
+        )
+
+    @staticmethod
+    def get_successful_transaction(status_response):
+        """ Return the first settled transaction of an invoice, or an empty dict. """
+        data = status_response.get('Data') or {}
+        for transaction in data.get('InvoiceTransactions') or []:
+            if isinstance(transaction, dict) and transaction.get('TransactionStatus') == TRANSACTION_STATUS_SUCCESS:
+                return transaction
+        return {}
+
+    @staticmethod
+    def get_invoice_value(status_response):
+        """
+        Return the amount MyFatoorah says it charged, as a Decimal.
+
+        Callers compare this against the basket total. Taking the amount from the
+        gateway rather than the basket is what makes that comparison meaningful.
+
+        Arguments:
+            status_response (dict): A GetPaymentStatus response body.
+
+        Returns:
+            Decimal or None: The invoice value, or None if it is absent/unparseable.
+        """
+        value = (status_response.get('Data') or {}).get('InvoiceValue')
+        if value is None:
+            return None
+        try:
+            return Decimal(str(value))
+        except (TypeError, ValueError, ArithmeticError):
+            logger.error('MyFatoorah returned an unparseable InvoiceValue [%r].', value)
+            return None
+
+    def verify_webhook_signature(self, raw_body, signature_header):
+        """
+        Verify a webhook's ``myfatoorah-signature`` header.
+
+        MyFatoorah signs the flattened ``Data`` object: its properties joined as
+        ``key=value,key2=value2``, UTF-8 encoded, HMAC SHA-256 with the account's
+        secret key, then base64.
+
+        Field order matters and MyFatoorah documents a specific order per event
+        type. This implementation uses the order the fields arrive in, which holds
+        for their current payloads but has NOT yet been confirmed against a real
+        delivery -- verify against a live webhook in staging before go-live. If
+        their order ever diverges from payload order, sign an explicit field list
+        per event type here rather than iterating the payload.
+
+        Fails closed: if no ``webhook_secret`` is configured, nothing verifies.
+
+        Arguments:
+            raw_body (dict): The parsed webhook body.
+            signature_header (str): Value of the ``myfatoorah-signature`` header.
+
+        Returns:
+            bool: True only if the signature matches.
+        """
+        if not self.webhook_secret:
+            logger.error(
+                'Rejecting MyFatoorah webhook: no webhook_secret is configured for this site.'
+            )
+            return False
+
+        if not signature_header:
+            logger.warning('Rejecting MyFatoorah webhook: no signature header present.')
+            return False
+
+        data = raw_body.get('Data')
+        if not isinstance(data, dict):
+            logger.warning('Rejecting MyFatoorah webhook: no Data object to verify.')
+            return False
+
+        message = ','.join(
+            '{key}={value}'.format(key=key, value='' if value is None else value)
+            for key, value in data.items()
+        )
+        expected = base64.b64encode(
+            hmac.new(
+                self.webhook_secret.encode('utf-8'),
+                message.encode('utf-8'),
+                hashlib.sha256,
+            ).digest()
+        ).decode('utf-8')
+
+        if not hmac.compare_digest(expected, signature_header):
+            logger.warning('Rejecting MyFatoorah webhook: signature mismatch.')
+            return False
+
+        return True
+
+    def handle_processor_response(self, response, basket=None):
+        """
+        Record a verified MyFatoorah payment.
+
+        Arguments:
+            response (dict): A GetPaymentStatus response body. Never the redirect
+                query string and never a raw webhook body -- callers must resolve
+                those to a verified status response first.
+
+        Keyword Arguments:
+            basket (Basket): Basket whose contents were purchased.
+
+        Returns:
+            HandledProcessorResponse
+        """
+        data = response.get('Data') or {}
+        transaction = self.get_successful_transaction(response)
+
+        invoice_id = data.get('InvoiceId')
+        # PaymentId identifies the individual transaction, which is what a future
+        # refund would reference; fall back to the invoice if it is missing.
+        transaction_id = transaction.get('PaymentId') or invoice_id
+
+        card = transaction.get('Card') or {}
+        # Already masked by MyFatoorah -- we never see a full PAN.
+        card_number = card.get('Number') or transaction.get('CardNumber')
+        card_type = card.get('Brand') or transaction.get('PaymentGateway')
+
+        self.record_processor_response(_scrub(response), transaction_id=transaction_id, basket=basket)
+        logger.info(
+            'Recorded MyFatoorah payment [%s] on invoice [%s] for basket [%d].',
+            transaction_id,
+            invoice_id,
+            basket.id,
+        )
+
+        # Amount and currency come from the gateway, not the basket. Callers verify
+        # they agree with the basket before reaching this point.
+        total = self.get_invoice_value(response)
+        currency = transaction.get('PaidCurrency') or basket.currency
+
+        return HandledProcessorResponse(
+            transaction_id=transaction_id,
+            total=total,
+            currency=currency,
+            card_number=card_number,
+            card_type=card_type,
+        )
+
+    def issue_credit(self, order_number, basket, reference_number, amount, currency):
+        raise NotImplementedError('The MyFatoorah payment processor does not support refunds.')

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -1,5 +1,8 @@
 
+import base64
 import datetime
+import hashlib
+import hmac
 import os
 import re
 from decimal import Decimal
@@ -1059,3 +1062,146 @@ class CyberSourceRESTAPIMixin:
             lambda x: x.group(1) + x.group(2).upper(),
             processor_json
         ).replace('links', '_links').replace('_self', 'self')
+
+
+class MyFatoorahMixin:
+    """ Mixin with MyFatoorah-specific response builders and mocks.
+
+    MyFatoorah is reached with plain ``requests`` calls, so responses are registered
+    with ``responses`` rather than by patching an SDK.
+    """
+
+    INVOICE_ID = 1234567
+    PAYMENT_ID = '0715570031362701'
+    INVOICE_URL = 'https://apitest.myfatoorah.com/KWT/ip/0715570031362701'
+    MASKED_CARD_NUMBER = '424242xxxxxx4242'
+    CARD_BRAND = 'Visa'
+
+    def myfatoorah_url(self, endpoint):
+        base_url = settings.PAYMENT_PROCESSOR_CONFIG['edx']['myfatoorah']['base_url']
+        return urljoin(base_url, endpoint)
+
+    def send_payment_response(self, invoice_id=None, invoice_url=None, is_success=True):
+        """ Build a SendPayment response body. """
+        if not is_success:
+            return {
+                'IsSuccess': False,
+                'Message': 'Invalid token',
+                'ValidationErrors': None,
+                'Data': None,
+            }
+
+        return {
+            'IsSuccess': True,
+            'Message': 'Invoice Created Successfully!',
+            'ValidationErrors': None,
+            'Data': {
+                'InvoiceId': invoice_id if invoice_id is not None else self.INVOICE_ID,
+                'InvoiceURL': invoice_url or self.INVOICE_URL,
+                'CustomerReference': None,
+                'UserDefinedField': None,
+            },
+        }
+
+    def payment_status_response(self, basket=None, invoice_status='Paid', transaction_status='Succss',
+                                invoice_value=None, customer_reference=None, paid_currency=None,
+                                include_card=True):
+        """ Build a GetPaymentStatus response body.
+
+        Defaults describe a settled payment matching ``basket``. Override the keyword
+        arguments to describe pending, failed, or tampered payments.
+        """
+        if invoice_value is None:
+            invoice_value = float(basket.total_incl_tax) if basket else 20.0
+        if customer_reference is None and basket is not None:
+            customer_reference = basket.order_number
+        if paid_currency is None and basket is not None:
+            paid_currency = basket.currency
+
+        transaction = {
+            'TransactionDate': '2026-08-01T10:00:00',
+            'PaymentGateway': 'VISA/MASTER',
+            'PaymentId': self.PAYMENT_ID,
+            'AuthorizationId': '556677',
+            'TransactionStatus': transaction_status,
+            'TransationValue': str(invoice_value),
+            'PaidCurrency': paid_currency,
+            'Error': None,
+        }
+        if include_card:
+            transaction['Card'] = {
+                'NameOnCard': 'Test Learner',
+                'Number': self.MASKED_CARD_NUMBER,
+                'ExpiryMonth': '12',
+                'ExpiryYear': '30',
+                'Brand': self.CARD_BRAND,
+                'Issuer': 'Test Bank',
+            }
+
+        return {
+            'IsSuccess': True,
+            'Message': 'Invoice Data Retrieved Successfully!',
+            'ValidationErrors': None,
+            'Data': {
+                'InvoiceId': self.INVOICE_ID,
+                'InvoiceStatus': invoice_status,
+                'InvoiceReference': '2026000123',
+                'CustomerReference': customer_reference,
+                'CreatedDate': '2026-08-01T09:59:00',
+                'InvoiceValue': invoice_value,
+                'CustomerName': 'Test Learner',
+                'CustomerEmail': 'learner@example.com',
+                'InvoiceTransactions': [transaction],
+            },
+        }
+
+    def mock_send_payment(self, body=None, status=200, **kwargs):
+        """ Register a mocked SendPayment response. """
+        body = body if body is not None else self.send_payment_response(**kwargs)
+        responses.add(
+            responses.POST,
+            self.myfatoorah_url('/v2/SendPayment'),
+            json=body,
+            status=status,
+        )
+        return body
+
+    def mock_payment_status(self, body=None, status=200, **kwargs):
+        """ Register a mocked GetPaymentStatus response. """
+        body = body if body is not None else self.payment_status_response(**kwargs)
+        responses.add(
+            responses.POST,
+            self.myfatoorah_url('/v2/GetPaymentStatus'),
+            json=body,
+            status=status,
+        )
+        return body
+
+    def signature_for(self, body, secret=None):
+        """ Compute the ``myfatoorah-signature`` header value for a webhook body. """
+        if secret is None:
+            secret = settings.PAYMENT_PROCESSOR_CONFIG['edx']['myfatoorah']['webhook_secret']
+        message = ','.join(
+            '{key}={value}'.format(key=key, value='' if value is None else value)
+            for key, value in body['Data'].items()
+        )
+        return base64.b64encode(
+            hmac.new(secret.encode('utf-8'), message.encode('utf-8'), hashlib.sha256).digest()
+        ).decode('utf-8')
+
+    def webhook_body(self, payment_id=None, invoice_id=None, event_code=1):
+        """ Build a webhook V2 PAYMENT_STATUS_CHANGED body. """
+        return {
+            'Event': {
+                'Code': event_code,
+                'Name': 'PAYMENT_STATUS_CHANGED',
+                'CountryIsoCode': 'KWT',
+                'CreationDate': '2026-08-01T10:00:00',
+            },
+            'Data': {
+                'InvoiceId': invoice_id if invoice_id is not None else self.INVOICE_ID,
+                'PaymentId': payment_id if payment_id is not None else self.PAYMENT_ID,
+                'InvoiceStatus': 'Paid',
+                'TransactionStatus': 'Succss',
+            },
+        }

--- a/ecommerce/extensions/payment/tests/processors/test_myfatoorah.py
+++ b/ecommerce/extensions/payment/tests/processors/test_myfatoorah.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+""" Tests of the MyFatoorah payment processor. """
+
+
+import json
+from decimal import Decimal
+
+import responses
+from oscar.apps.payment.exceptions import GatewayError
+
+from ecommerce.extensions.payment.exceptions import MissingTransactionDetailError
+from ecommerce.extensions.payment.processors.myfatoorah import MyFatoorah, _scrub
+from ecommerce.extensions.payment.tests.mixins import MyFatoorahMixin
+from ecommerce.extensions.payment.tests.processors.mixins import PaymentProcessorTestCaseMixin
+from ecommerce.tests.testcases import TestCase
+
+
+class MyFatoorahTests(MyFatoorahMixin, PaymentProcessorTestCaseMixin, TestCase):
+    """ Tests of the MyFatoorah processor. """
+
+    processor_class = MyFatoorah
+    processor_name = 'myfatoorah'
+
+    @responses.activate
+    def test_get_transaction_parameters(self):
+        """ Verify the processor creates an invoice and returns its hosted payment page. """
+        self.mock_send_payment()
+
+        response = self.processor.get_transaction_parameters(self.basket)
+
+        self.assertEqual(response, {'payment_page_url': self.INVOICE_URL})
+
+        request_body = json.loads(responses.calls[-1].request.body)
+        self.assertEqual(request_body['InvoiceValue'], float(self.basket.total_incl_tax))
+        self.assertEqual(request_body['DisplayCurrencyIso'], self.basket.currency)
+        self.assertEqual(request_body['CustomerReference'], self.basket.order_number)
+        self.assertEqual(request_body['NotificationOption'], 'LNK')
+        self.assertIn('/payment/myfatoorah/callback/', request_body['CallBackUrl'])
+
+        # The audit row is what lets the callback find this basket again.
+        self.assert_processor_response_recorded(
+            self.processor.NAME,
+            self.INVOICE_ID,
+            _scrub(self.send_payment_response()),
+            basket=self.basket,
+        )
+
+    @responses.activate
+    def test_get_transaction_parameters_sends_bearer_token(self):
+        """ Verify the API token is sent as a bearer token. """
+        self.mock_send_payment()
+
+        self.processor.get_transaction_parameters(self.basket)
+
+        self.assertEqual(
+            responses.calls[-1].request.headers['Authorization'],
+            'Bearer fake-myfatoorah-api-token',
+        )
+
+    @responses.activate
+    def test_get_transaction_parameters_gateway_error(self):
+        """ Verify a rejected invoice raises GatewayError and is recorded. """
+        self.mock_send_payment(is_success=False)
+
+        with self.assertRaises(GatewayError):
+            self.processor.get_transaction_parameters(self.basket)
+
+    @responses.activate
+    def test_get_transaction_parameters_without_payment_url(self):
+        """ Verify a success response missing InvoiceURL is still treated as a failure. """
+        body = self.send_payment_response()
+        del body['Data']['InvoiceURL']
+        self.mock_send_payment(body=body)
+
+        with self.assertRaises(GatewayError):
+            self.processor.get_transaction_parameters(self.basket)
+
+    @responses.activate
+    def test_get_transaction_parameters_unparseable_response(self):
+        """ Verify a non-JSON response raises GatewayError rather than propagating ValueError. """
+        responses.add(
+            responses.POST,
+            self.myfatoorah_url('/v2/SendPayment'),
+            body='<html>gateway down</html>',
+            status=502,
+        )
+
+        with self.assertRaises(GatewayError):
+            self.processor.get_transaction_parameters(self.basket)
+
+    @responses.activate
+    def test_get_payment_status(self):
+        """ Verify payment status is looked up by PaymentId, as MyFatoorah recommends. """
+        self.mock_payment_status(basket=self.basket)
+
+        response = self.processor.get_payment_status(self.PAYMENT_ID)
+
+        self.assertTrue(self.processor.is_paid(response))
+        request_body = json.loads(responses.calls[-1].request.body)
+        self.assertEqual(request_body, {'Key': self.PAYMENT_ID, 'KeyType': 'PaymentId'})
+
+    @responses.activate
+    def test_get_payment_status_by_invoice_id(self):
+        """ Verify the lookup can fall back to an invoice ID. """
+        self.mock_payment_status(basket=self.basket)
+
+        self.processor.get_payment_status(self.INVOICE_ID, key_type='InvoiceId')
+
+        request_body = json.loads(responses.calls[-1].request.body)
+        self.assertEqual(request_body, {'Key': str(self.INVOICE_ID), 'KeyType': 'InvoiceId'})
+
+    @responses.activate
+    def test_get_payment_status_without_invoice(self):
+        """ Verify a response carrying no invoice detail raises. """
+        body = self.payment_status_response(basket=self.basket)
+        body['Data'] = None
+        self.mock_payment_status(body=body)
+
+        with self.assertRaises(MissingTransactionDetailError):
+            self.processor.get_payment_status(self.PAYMENT_ID)
+
+    def test_is_paid_requires_both_invoice_and_transaction(self):
+        """ Verify a paid invoice with no settled transaction is not treated as paid.
+
+        Guards against a pending or failed attempt on an otherwise paid-looking
+        invoice being accepted.
+        """
+        self.assertTrue(self.processor.is_paid(self.payment_status_response(basket=self.basket)))
+        self.assertFalse(
+            self.processor.is_paid(self.payment_status_response(basket=self.basket, invoice_status='Pending'))
+        )
+        self.assertFalse(
+            self.processor.is_paid(
+                self.payment_status_response(basket=self.basket, transaction_status='Failed')
+            )
+        )
+
+    def test_get_invoice_value(self):
+        """ Verify the charged amount is read from the gateway response as a Decimal. """
+        response = self.payment_status_response(basket=self.basket, invoice_value=20.0)
+        self.assertEqual(self.processor.get_invoice_value(response), Decimal('20.0'))
+
+        response['Data']['InvoiceValue'] = 'not-a-number'
+        self.assertIsNone(self.processor.get_invoice_value(response))
+
+        del response['Data']['InvoiceValue']
+        self.assertIsNone(self.processor.get_invoice_value(response))
+
+    def test_handle_processor_response(self):
+        """ Verify the processor records the payment and reports the gateway's own amount. """
+        response = self.payment_status_response(basket=self.basket)
+
+        handled = self.processor.handle_processor_response(response, basket=self.basket)
+
+        self.assertEqual(handled.transaction_id, self.PAYMENT_ID)
+        self.assertEqual(handled.total, self.basket.total_incl_tax)
+        self.assertEqual(handled.currency, self.basket.currency)
+        self.assertEqual(handled.card_number, self.MASKED_CARD_NUMBER)
+        self.assertEqual(handled.card_type, self.CARD_BRAND)
+
+        self.assert_processor_response_recorded(
+            self.processor.NAME,
+            self.PAYMENT_ID,
+            _scrub(response),
+            basket=self.basket,
+        )
+
+    def test_handle_processor_response_without_card_detail(self):
+        """ Verify a payment method that reports no card (e.g. KNET) still records. """
+        response = self.payment_status_response(basket=self.basket, include_card=False)
+
+        handled = self.processor.handle_processor_response(response, basket=self.basket)
+
+        self.assertIsNone(handled.card_number)
+        self.assertEqual(handled.card_type, 'VISA/MASTER')
+
+    def test_issue_credit(self):
+        """ Verify refunds are not supported. """
+        with self.assertRaises(NotImplementedError):
+            self.processor.issue_credit(
+                self.basket.order_number, self.basket, self.PAYMENT_ID, Decimal('20.00'), 'USD'
+            )
+
+    def test_issue_credit_error(self):
+        """ Refunds are unsupported, so there is no gateway error path to exercise. """
+        with self.assertRaises(NotImplementedError):
+            self.processor.issue_credit(
+                self.basket.order_number, self.basket, self.PAYMENT_ID, Decimal('20.00'), 'USD'
+            )
+
+    def test_verify_webhook_signature(self):
+        """ Verify a correctly signed webhook body is accepted. """
+        body = self.webhook_body()
+        self.assertTrue(self.processor.verify_webhook_signature(body, self.signature_for(body)))
+
+    def test_verify_webhook_signature_rejects_bad_signature(self):
+        """ Verify a wrong signature, a missing header, and a wrong secret are all rejected. """
+        body = self.webhook_body()
+
+        self.assertFalse(self.processor.verify_webhook_signature(body, 'not-the-signature'))
+        self.assertFalse(self.processor.verify_webhook_signature(body, None))
+        self.assertFalse(
+            self.processor.verify_webhook_signature(body, self.signature_for(body, secret='wrong-secret'))
+        )
+
+    def test_verify_webhook_signature_fails_closed_without_secret(self):
+        """ Verify verification fails when no webhook secret is configured.
+
+        A missing secret must not be read as "no verification required".
+        """
+        body = self.webhook_body()
+        signature = self.signature_for(body)
+        self.processor.webhook_secret = None
+
+        self.assertFalse(self.processor.verify_webhook_signature(body, signature))
+
+    def test_verify_webhook_signature_without_data(self):
+        """ Verify a body with no Data object is rejected rather than crashing. """
+        self.assertFalse(self.processor.verify_webhook_signature({'Event': {'Code': 1}}, 'signature'))
+
+
+class ScrubTests(MyFatoorahMixin, TestCase):
+    """ Tests of the payload allow-list applied before anything is persisted.
+
+    These encode a PCI guarantee: what MyFatoorah sends us is not what we store.
+    """
+
+    def test_scrub_drops_cardholder_name_and_expiry(self):
+        """ Verify only the masked PAN and brand survive from the Card object. """
+        scrubbed = _scrub(self.payment_status_response())
+
+        card = scrubbed['Data']['InvoiceTransactions'][0]['Card']
+        self.assertEqual(card, {'Number': self.MASKED_CARD_NUMBER, 'Brand': self.CARD_BRAND})
+        self.assertNotIn('NameOnCard', card)
+        self.assertNotIn('ExpiryMonth', card)
+        self.assertNotIn('ExpiryYear', card)
+
+    def test_scrub_drops_customer_contact_detail(self):
+        """ Verify learner contact details are not duplicated into the audit row. """
+        scrubbed = _scrub(self.payment_status_response())
+
+        self.assertNotIn('CustomerEmail', scrubbed['Data'])
+        self.assertNotIn('CustomerName', scrubbed['Data'])
+
+    def test_scrub_keeps_the_fields_we_reconcile_on(self):
+        """ Verify scrubbing does not discard what we need for audit and reconciliation. """
+        scrubbed = _scrub(self.payment_status_response(customer_reference='EDX-100001'))
+
+        data = scrubbed['Data']
+        self.assertEqual(data['InvoiceId'], self.INVOICE_ID)
+        self.assertEqual(data['InvoiceStatus'], 'Paid')
+        self.assertEqual(data['CustomerReference'], 'EDX-100001')
+        self.assertIn('InvoiceValue', data)
+
+        transaction = data['InvoiceTransactions'][0]
+        self.assertEqual(transaction['PaymentId'], self.PAYMENT_ID)
+        self.assertEqual(transaction['TransactionStatus'], 'Succss')
+
+    def test_scrub_drops_unknown_fields(self):
+        """ Verify a field MyFatoorah adds later is not persisted just because it is new. """
+        response = self.payment_status_response()
+        response['Data']['SomeNewSensitiveField'] = 'nope'
+        response['Data']['InvoiceTransactions'][0]['AnotherNewField'] = 'also nope'
+
+        scrubbed = _scrub(response)
+
+        self.assertNotIn('SomeNewSensitiveField', scrubbed['Data'])
+        self.assertNotIn('AnotherNewField', scrubbed['Data']['InvoiceTransactions'][0])
+
+    def test_scrub_handles_malformed_payloads(self):
+        """ Verify scrubbing never raises on unexpected shapes. """
+        self.assertEqual(_scrub(None), {})
+        self.assertEqual(_scrub('a string'), {})
+        self.assertEqual(_scrub({}), {})
+        self.assertEqual(_scrub({'IsSuccess': True, 'Data': None}), {'IsSuccess': True})

--- a/ecommerce/extensions/payment/tests/views/test_myfatoorah.py
+++ b/ecommerce/extensions/payment/tests/views/test_myfatoorah.py
@@ -1,0 +1,324 @@
+# -*- coding: utf-8 -*-
+""" Tests of the MyFatoorah payment views.
+
+The tests that matter most here are the ones asserting an order is *not* placed:
+they encode the trust boundary between us and the gateway.
+"""
+
+
+import json
+
+import responses
+from django.urls import reverse
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import SEAT_PRODUCT_CLASS_NAME
+from ecommerce.extensions.checkout.utils import get_receipt_page_url
+from ecommerce.extensions.payment.processors.myfatoorah import MyFatoorah
+from ecommerce.extensions.payment.tests.mixins import MyFatoorahMixin, PaymentEventsMixin
+from ecommerce.extensions.test.factories import create_basket
+from ecommerce.tests.testcases import TestCase
+
+JSON = 'application/json'
+
+Order = get_model('order', 'Order')
+PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
+ProductClass = get_model('catalogue', 'ProductClass')
+SourceType = get_model('payment', 'SourceType')
+
+
+class MyFatoorahViewTestMixin(MyFatoorahMixin, PaymentEventsMixin):
+    """ Shared setup: a frozen basket with a MyFatoorah invoice already recorded against it. """
+
+    def setUp(self):
+        super(MyFatoorahViewTestMixin, self).setUp()
+        self.price = '100.0'
+        self.user = self.create_user()
+        self.seat_product_class, __ = ProductClass.objects.get_or_create(name=SEAT_PRODUCT_CLASS_NAME)
+        self.basket = create_basket(
+            owner=self.user, site=self.site, price=self.price, product_class=self.seat_product_class
+        )
+        self.basket.freeze()
+
+        self.processor = MyFatoorah(self.site)
+        self.processor_name = self.processor.NAME
+
+        # Stands in for the row get_transaction_parameters writes before the learner
+        # leaves for MyFatoorah; it is how the views find this basket again.
+        self.processor.record_processor_response(
+            {'IsSuccess': True}, transaction_id=self.INVOICE_ID, basket=self.basket
+        )
+
+    def assert_no_order_placed(self):
+        self.assertFalse(Order.objects.filter(number=self.basket.order_number).exists())
+
+    def assert_myfatoorah_source_exists(self):
+        """ Verify the order carries a MyFatoorah payment source labelled with the masked PAN. """
+        self.assert_payment_source_exists(
+            self.basket,
+            SourceType.objects.get(name=self.processor_name),
+            self.PAYMENT_ID,
+            self.MASKED_CARD_NUMBER,
+        )
+
+    def get_status_request_body(self):
+        """ Return the body of the GetPaymentStatus call.
+
+        Order fulfillment makes its own outbound requests, so the status lookup is
+        not reliably the last recorded call.
+        """
+        for call in responses.calls:
+            if call.request.url.endswith('/v2/GetPaymentStatus'):
+                return json.loads(call.request.body)
+        return None
+
+
+class MyFatoorahCallbackViewTests(MyFatoorahViewTestMixin, TestCase):
+    """ Tests of the learner-facing return URL. """
+
+    path = reverse('myfatoorah:callback')
+
+    def _get(self, payment_id=None):
+        params = {'paymentId': payment_id or self.PAYMENT_ID}
+        return self.client.get(self.path, params)
+
+    @responses.activate
+    def test_successful_payment_places_order(self):
+        """ Verify a settled payment produces an order, a payment source, and a receipt redirect. """
+        self.mock_payment_status(basket=self.basket)
+
+        response = self._get()
+
+        self.assertRedirects(
+            response,
+            get_receipt_page_url(
+                order_number=self.basket.order_number,
+                site_configuration=self.basket.site.siteconfiguration,
+                disable_back_button=True,
+            ),
+            fetch_redirect_response=False,
+        )
+
+        self.assertTrue(Order.objects.filter(number=self.basket.order_number).exists())
+        self.assert_myfatoorah_source_exists()
+
+    @responses.activate
+    def test_payment_status_is_verified_server_side(self):
+        """ Verify the view asks MyFatoorah rather than trusting the query string. """
+        self.mock_payment_status(basket=self.basket)
+
+        self._get()
+
+        self.assertEqual(
+            self.get_status_request_body(), {'Key': self.PAYMENT_ID, 'KeyType': 'PaymentId'}
+        )
+
+    def test_missing_payment_id(self):
+        """ Verify a callback with no payment reference is refused without any gateway call. """
+        response = self.client.get(self.path)
+
+        self.assertRedirects(response, reverse('checkout:error'), fetch_redirect_response=False)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_unpaid_invoice_places_no_order(self):
+        """ Verify a pending invoice does not become an order.
+
+        This is the case a learner can trigger by hand-crafting a return URL.
+        """
+        self.mock_payment_status(basket=self.basket, invoice_status='Pending')
+
+        response = self._get()
+
+        self.assertRedirects(response, reverse('checkout:error'), fetch_redirect_response=False)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_failed_transaction_places_no_order(self):
+        """ Verify a failed transaction on a paid-looking invoice places no order. """
+        self.mock_payment_status(basket=self.basket, transaction_status='Failed')
+
+        response = self._get()
+
+        self.assertRedirects(response, reverse('checkout:error'), fetch_redirect_response=False)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_underpayment_places_no_order(self):
+        """ Verify a charge smaller than the basket total places no order. """
+        self.mock_payment_status(basket=self.basket, invoice_value=1.0)
+
+        response = self._get()
+
+        self.assertRedirects(response, reverse('checkout:error'), fetch_redirect_response=False)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_currency_mismatch_places_no_order(self):
+        """ Verify a payment settled in another currency places no order.
+
+        Without this check, 100 of a weaker currency would buy a 100 USD seat.
+        """
+        self.mock_payment_status(basket=self.basket, paid_currency='KWD')
+
+        response = self._get()
+
+        self.assertRedirects(response, reverse('checkout:error'), fetch_redirect_response=False)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_customer_reference_mismatch_places_no_order(self):
+        """ Verify a mismatch between the gateway's reference and the basket places no order. """
+        self.mock_payment_status(basket=self.basket, customer_reference='EDX-SOMEONE-ELSE')
+
+        response = self._get()
+
+        self.assertRedirects(response, reverse('checkout:error'), fetch_redirect_response=False)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_unknown_invoice_places_no_order(self):
+        """ Verify a payment we have no record of places no order. """
+        body = self.payment_status_response(basket=self.basket)
+        body['Data']['InvoiceId'] = 9999999
+        self.mock_payment_status(body=body)
+
+        response = self._get()
+
+        self.assertRedirects(response, reverse('checkout:error'), fetch_redirect_response=False)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_gateway_failure_places_no_order(self):
+        """ Verify a gateway outage places no order. """
+        self.mock_payment_status(body={'IsSuccess': False, 'Message': 'Server error'}, status=500)
+
+        response = self._get()
+
+        self.assertRedirects(response, reverse('checkout:error'), fetch_redirect_response=False)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_repeated_callback_places_one_order(self):
+        """ Verify a learner refreshing the return URL does not buy the seat twice. """
+        self.mock_payment_status(basket=self.basket)
+        self.mock_payment_status(basket=self.basket)
+
+        self._get()
+        second_response = self._get()
+
+        self.assertEqual(Order.objects.filter(number=self.basket.order_number).count(), 1)
+        self.assertEqual(second_response.status_code, 302)
+
+
+class MyFatoorahWebhookViewTests(MyFatoorahViewTestMixin, TestCase):
+    """ Tests of the server-to-server notification endpoint. """
+
+    path = reverse('myfatoorah:webhook')
+
+    def _post(self, body=None, signature=None):
+        body = body if body is not None else self.webhook_body()
+        if signature is None:
+            signature = self.signature_for(body)
+        return self.client.post(
+            self.path,
+            json.dumps(body),
+            content_type=JSON,
+            HTTP_MYFATOORAH_SIGNATURE=signature,
+        )
+
+    @responses.activate
+    def test_signed_webhook_places_order(self):
+        """ Verify a correctly signed notification for a settled payment places an order. """
+        self.mock_payment_status(basket=self.basket)
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Order.objects.filter(number=self.basket.order_number).exists())
+        self.assert_myfatoorah_source_exists()
+
+    def test_unsigned_webhook_rejected(self):
+        """ Verify a notification with no signature header is refused. """
+        response = self._post(signature='')
+
+        self.assertEqual(response.status_code, 400)
+        self.assert_no_order_placed()
+
+    def test_bad_signature_rejected(self):
+        """ Verify a forged notification is refused before any gateway call is made. """
+        response = self._post(signature='YmFkLXNpZ25hdHVyZQ==')
+
+        self.assertEqual(response.status_code, 400)
+        self.assert_no_order_placed()
+
+    def test_tampered_body_rejected(self):
+        """ Verify a body altered after signing is refused. """
+        body = self.webhook_body()
+        signature = self.signature_for(body)
+        body['Data']['InvoiceId'] = 9999999
+
+        response = self._post(body=body, signature=signature)
+
+        self.assertEqual(response.status_code, 400)
+        self.assert_no_order_placed()
+
+    def test_unrelated_event_ignored(self):
+        """ Verify a non-payment event is acknowledged but ignored. """
+        body = self.webhook_body(event_code=2)
+
+        response = self._post(body=body)
+
+        self.assertEqual(response.status_code, 204)
+        self.assert_no_order_placed()
+
+    def test_webhook_without_payment_reference_rejected(self):
+        """ Verify a payment event carrying no identifiers is refused. """
+        body = self.webhook_body()
+        del body['Data']['PaymentId']
+        del body['Data']['InvoiceId']
+
+        response = self._post(body=body)
+
+        self.assertEqual(response.status_code, 400)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_unpaid_webhook_places_no_order(self):
+        """ Verify a signed notification about an unpaid invoice places no order.
+
+        A valid signature proves the message came from MyFatoorah, not that the
+        payment succeeded -- the status lookup is still what decides.
+        """
+        self.mock_payment_status(basket=self.basket, invoice_status='Pending')
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_no_order_placed()
+
+    @responses.activate
+    def test_webhook_after_callback_places_one_order(self):
+        """ Verify the callback and the webhook together produce exactly one order.
+
+        Both fire for a normal purchase, so idempotency here is the difference
+        between one enrolment and a duplicate order.
+        """
+        self.mock_payment_status(basket=self.basket)
+        self.mock_payment_status(basket=self.basket)
+
+        self.client.get(reverse('myfatoorah:callback'), {'paymentId': self.PAYMENT_ID})
+        response = self._post()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Order.objects.filter(number=self.basket.order_number).count(), 1)
+
+    @responses.activate
+    def test_gateway_failure_is_acknowledged(self):
+        """ Verify a gateway outage still returns 200 so MyFatoorah stops retrying. """
+        self.mock_payment_status(body={'IsSuccess': False, 'Message': 'Server error'}, status=500)
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_no_order_placed()

--- a/ecommerce/extensions/payment/urls.py
+++ b/ecommerce/extensions/payment/urls.py
@@ -1,7 +1,17 @@
 
 from django.conf.urls import include, url
 
-from ecommerce.extensions.payment.views import PaymentFailedView, SDNFailure, authorizenet, cybersource, cybersource_microform, paypal, stripe, cowpay
+from ecommerce.extensions.payment.views import (
+    PaymentFailedView,
+    SDNFailure,
+    authorizenet,
+    cowpay,
+    cybersource,
+    cybersource_microform,
+    myfatoorah,
+    paypal,
+    stripe
+)
 
 CYBERSOURCE_APPLE_PAY_URLS = [
     url(r'^authorize/$', cybersource.CybersourceApplePayAuthorizationView.as_view(), name='authorize'),
@@ -42,6 +52,13 @@ COWPAY_URLS = [
     url(r'^execute/$', cowpay.CowpayExecutionView.as_view(), name='execute'),
 ]
 
+MYFATOORAH_URLS = [
+    # Where the learner is returned to after MyFatoorah's hosted payment page.
+    url(r'^callback/$', myfatoorah.MyFatoorahCallbackView.as_view(), name='callback'),
+    # Server-to-server notification from MyFatoorah; signed, not authenticated.
+    url(r'^webhook/$', myfatoorah.MyFatoorahWebhookView.as_view(), name='webhook'),
+]
+
 urlpatterns = [
     url(r'^cybersource/', include((CYBERSOURCE_URLS, 'cybersource'))),
     url(r'^error/$', PaymentFailedView.as_view(), name='payment_error'),
@@ -50,4 +67,5 @@ urlpatterns = [
     url(r'^stripe/', include((STRIPE_URLS, 'stripe'))),
     url(r'^authorizenet/', include((AUTHORIZENET_URLS, 'authorizenet'))),
     url(r'^cowpay/', include((COWPAY_URLS, 'cowpay'))),
+    url(r'^myfatoorah/', include((MYFATOORAH_URLS, 'myfatoorah'))),
 ]

--- a/ecommerce/extensions/payment/views/myfatoorah.py
+++ b/ecommerce/extensions/payment/views/myfatoorah.py
@@ -1,0 +1,309 @@
+""" Views for interacting with the MyFatoorah payment processor.
+
+There are two ways MyFatoorah tells us a payment happened, and both land here:
+
+* ``MyFatoorahCallbackView`` -- the learner's browser is redirected back to us
+  after they finish on MyFatoorah's hosted page.
+* ``MyFatoorahWebhookView`` -- MyFatoorah's servers POST us a signed notification.
+
+The webhook is not redundant. If the learner pays and then closes the tab before
+the redirect completes, the callback never fires and the payment would otherwise
+never become an enrolment.
+
+Neither entry point is trusted about payment state. Both treat their input as an
+opaque lookup key, re-ask MyFatoorah server-to-server via ``get_payment_status``,
+and only then place an order -- see ``MyFatoorahPaymentMixin.place_order_for_payment``,
+which both share so their trust checks cannot drift apart.
+"""
+
+
+import logging
+
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.db import transaction
+from django.http import HttpResponse
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import View
+from oscar.apps.partner import strategy
+from oscar.apps.payment.exceptions import PaymentError
+from oscar.core.loading import get_class, get_model
+from rest_framework.views import APIView
+
+from ecommerce.extensions.basket.utils import basket_add_organization_attribute
+from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
+from ecommerce.extensions.checkout.utils import get_receipt_page_url
+from ecommerce.extensions.payment.exceptions import AuthorizationError, InvalidBasketError, PartialAuthorizationError
+from ecommerce.extensions.payment.processors.myfatoorah import EVENT_PAYMENT_STATUS_CHANGED, MyFatoorah
+
+logger = logging.getLogger(__name__)
+
+Applicator = get_class('offer.applicator', 'Applicator')
+Order = get_model('order', 'Order')
+PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
+
+SIGNATURE_HEADER = 'HTTP_MYFATOORAH_SIGNATURE'
+
+
+class MyFatoorahPaymentMixin(EdxOrderPlacementMixin):
+    """ Shared verify-then-place-order logic for the callback and the webhook. """
+
+    @property
+    def payment_processor(self):
+        return MyFatoorah(self.request.site)
+
+    def get_basket(self, invoice_id):
+        """
+        Retrieve the basket an invoice was created for.
+
+        The link is the ``PaymentProcessorResponse`` row written by
+        ``get_transaction_parameters`` before the learner left for MyFatoorah.
+
+        Arguments:
+            invoice_id: ``InvoiceId`` reported by MyFatoorah.
+
+        Returns:
+            Basket or None.
+        """
+        if not invoice_id:
+            return None
+
+        try:
+            basket = PaymentProcessorResponse.objects.get(
+                processor_name=self.payment_processor.NAME,
+                transaction_id=invoice_id,
+            ).basket
+        except MultipleObjectsReturned:
+            logger.warning('Duplicate MyFatoorah invoice ID [%s] received.', invoice_id)
+            return None
+        except (ObjectDoesNotExist, ValueError):
+            logger.warning('No basket found for MyFatoorah invoice ID [%s].', invoice_id)
+            return None
+
+        if basket is None:
+            return None
+
+        basket.strategy = strategy.Default()
+        Applicator().apply(basket, basket.owner, self.request)
+        return basket
+
+    def place_order_for_payment(self, request, key, key_type='PaymentId'):
+        """
+        Verify a payment with MyFatoorah and place the order if it is genuinely paid.
+
+        Arguments:
+            request: The incoming request.
+            key: The ``paymentId``/``InvoiceId`` supplied by MyFatoorah. Untrusted.
+
+        Keyword Arguments:
+            key_type (str): Which identifier ``key`` is.
+
+        Returns:
+            tuple: ``(basket, order)``. ``order`` is the pre-existing order when this
+                payment was already processed, so callers get idempotency for free.
+
+        Raises:
+            InvalidBasketError: No basket could be tied to the payment.
+            AuthorizationError: MyFatoorah does not consider the invoice paid.
+            PartialAuthorizationError: The charged amount or currency disagrees with the basket.
+            PaymentError: Recording the payment failed.
+        """
+        processor = self.payment_processor
+        status_response = processor.get_payment_status(key, key_type=key_type)
+        data = status_response.get('Data') or {}
+        invoice_id = data.get('InvoiceId')
+
+        basket = self.get_basket(invoice_id)
+        if not basket:
+            raise InvalidBasketError(
+                'No basket found for MyFatoorah invoice {}.'.format(invoice_id)
+            )
+
+        # MyFatoorah echoes back the order number we sent as CustomerReference.
+        # If it disagrees with the basket we resolved, something is wrong enough
+        # that we should not create an order.
+        customer_reference = data.get('CustomerReference')
+        if customer_reference and customer_reference != basket.order_number:
+            raise InvalidBasketError(
+                'MyFatoorah invoice {invoice} reports CustomerReference [{reference}] but its basket '
+                '[{basket_id}] has order number [{order_number}].'.format(
+                    invoice=invoice_id,
+                    reference=customer_reference,
+                    basket_id=basket.id,
+                    order_number=basket.order_number,
+                )
+            )
+
+        if not processor.is_paid(status_response):
+            processor.record_status_response(status_response, basket=basket)
+            raise AuthorizationError(
+                'MyFatoorah invoice {invoice} is not paid (status [{status}]).'.format(
+                    invoice=invoice_id, status=data.get('InvoiceStatus')
+                )
+            )
+
+        # Compare against what the gateway says it charged, not what we asked for.
+        invoice_value = processor.get_invoice_value(status_response)
+        if invoice_value is None or invoice_value != basket.total_incl_tax:
+            raise PartialAuthorizationError(
+                'MyFatoorah invoice {invoice} charged [{charged}] but basket [{basket_id}] '
+                'totals [{expected}].'.format(
+                    invoice=invoice_id,
+                    charged=invoice_value,
+                    basket_id=basket.id,
+                    expected=basket.total_incl_tax,
+                )
+            )
+
+        paid_currency = (processor.get_successful_transaction(status_response) or {}).get('PaidCurrency')
+        if paid_currency and paid_currency != basket.currency:
+            raise PartialAuthorizationError(
+                'MyFatoorah invoice {invoice} was paid in [{paid}] but basket [{basket_id}] '
+                'is priced in [{expected}].'.format(
+                    invoice=invoice_id,
+                    paid=paid_currency,
+                    basket_id=basket.id,
+                    expected=basket.currency,
+                )
+            )
+
+        # The callback and the webhook can both fire for the same payment, in either
+        # order. Whoever loses the race must not place a second order.
+        existing_order = Order.objects.filter(number=basket.order_number).first()
+        if existing_order:
+            logger.info(
+                'Order [%s] already exists for MyFatoorah invoice [%s]; skipping order placement.',
+                basket.order_number,
+                invoice_id,
+            )
+            return basket, existing_order
+
+        with transaction.atomic():
+            self.handle_payment(status_response, basket)
+
+        order = self.create_order(request, basket)
+
+        try:
+            self.handle_post_order(order)
+        except Exception:  # pylint: disable=broad-except
+            self.log_order_placement_exception(basket.order_number, basket.id)
+
+        return basket, order
+
+
+class MyFatoorahCallbackView(MyFatoorahPaymentMixin, View):
+    """ Handle a learner returning from MyFatoorah's hosted payment page. """
+
+    # Disable atomicity for the view. Otherwise, we'd be unable to commit to the database
+    # until the request had concluded; Django will refuse to commit when an atomic() block
+    # is active, since that would break atomicity. Without an order present in the database
+    # at the time fulfillment is attempted, asynchronous order fulfillment tasks will fail.
+    @method_decorator(transaction.non_atomic_requests)
+    def dispatch(self, request, *args, **kwargs):
+        return super(MyFatoorahCallbackView, self).dispatch(request, *args, **kwargs)
+
+    def get_basket(self, invoice_id):
+        """ Attach any organization attribute carried on the return URL before the order is placed. """
+        basket = super(MyFatoorahCallbackView, self).get_basket(invoice_id)
+        if basket:
+            basket_add_organization_attribute(basket, self.request.GET)
+        return basket
+
+    def get(self, request):
+        """
+        Verify the payment behind a returning learner and show them their receipt.
+
+        Note this is a GET return URL rather than a webhook, so it is not CSRF
+        exempt and it carries no authority of its own -- ``paymentId`` is only a
+        lookup key.
+        """
+        payment_id = request.GET.get('paymentId') or request.GET.get('Id')
+
+        if not payment_id:
+            logger.warning('MyFatoorah callback received without a paymentId.')
+            return redirect(reverse('checkout:error'))
+
+        try:
+            basket, __ = self.place_order_for_payment(request, payment_id)
+        except (AuthorizationError, PartialAuthorizationError) as exc:
+            logger.warning('Declining MyFatoorah payment [%s]: %s', payment_id, exc)
+            return redirect(reverse('checkout:error'))
+        except InvalidBasketError as exc:
+            logger.error('Cannot process MyFatoorah payment [%s]: %s', payment_id, exc)
+            return redirect(reverse('checkout:error'))
+        except PaymentError:
+            logger.exception('Failed to record MyFatoorah payment [%s].', payment_id)
+            return redirect(reverse('checkout:error'))
+        except Exception:  # pylint: disable=broad-except
+            # The payment may well have gone through even though we failed to place the
+            # order. The learner sees an error, but the webhook is the backstop that
+            # will place the order if MyFatoorah confirms the payment.
+            logger.exception('Unexpected error handling MyFatoorah payment [%s].', payment_id)
+            return redirect(reverse('checkout:error'))
+
+        return redirect(
+            get_receipt_page_url(
+                order_number=basket.order_number,
+                site_configuration=basket.site.siteconfiguration,
+                disable_back_button=True,
+            )
+        )
+
+
+class MyFatoorahWebhookView(MyFatoorahPaymentMixin, APIView):
+    """
+    Handle MyFatoorah's server-to-server payment notification.
+
+    Returns 200 for anything it has finished with -- including payments it decided
+    not to act on -- so MyFatoorah stops retrying. Only an unverifiable signature
+    or a malformed body gets a 4xx.
+    """
+
+    authentication_classes = ()
+    permission_classes = ()
+
+    @method_decorator(transaction.non_atomic_requests)
+    @csrf_exempt
+    def dispatch(self, request, *args, **kwargs):
+        return super(MyFatoorahWebhookView, self).dispatch(request, *args, **kwargs)
+
+    def post(self, request):
+        body = request.data
+        if not isinstance(body, dict):
+            logger.warning('Rejecting MyFatoorah webhook: body is not an object.')
+            return HttpResponse(status=400)
+
+        if not self.payment_processor.verify_webhook_signature(body, request.META.get(SIGNATURE_HEADER)):
+            # verify_webhook_signature has already logged the specific reason.
+            return HttpResponse(status=400)
+
+        event_code = (body.get('Event') or {}).get('Code')
+        if event_code != EVENT_PAYMENT_STATUS_CHANGED:
+            logger.info('Ignoring MyFatoorah webhook event code [%s].', event_code)
+            return HttpResponse(status=204)
+
+        data = body.get('Data') or {}
+        # Prefer PaymentId, which MyFatoorah recommends for status lookups, but
+        # fall back to the invoice if this event only carries that.
+        key = data.get('PaymentId')
+        key_type = 'PaymentId'
+        if not key:
+            key = data.get('InvoiceId')
+            key_type = 'InvoiceId'
+
+        if not key:
+            logger.warning('Rejecting MyFatoorah webhook: no PaymentId or InvoiceId in Data.')
+            return HttpResponse(status=400)
+
+        try:
+            self.place_order_for_payment(request, key, key_type=key_type)
+        except (AuthorizationError, PartialAuthorizationError) as exc:
+            logger.warning('Declining MyFatoorah webhook payment [%s]: %s', key, exc)
+        except InvalidBasketError as exc:
+            logger.error('Cannot process MyFatoorah webhook payment [%s]: %s', key, exc)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception('Unexpected error handling MyFatoorah webhook payment [%s].', key)
+
+        return HttpResponse(status=200)

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -137,6 +137,7 @@ PAYMENT_PROCESSORS = (
     'ecommerce.extensions.payment.processors.authorizenet.AuthorizeNet',
     'ecommerce.extensions.payment.processors.authorizenet.AuthorizenetClient',
     'ecommerce.extensions.payment.processors.cowpay.Cowpay',
+    'ecommerce.extensions.payment.processors.myfatoorah.MyFatoorah',
 )
 
 PAYMENT_PROCESSOR_RECEIPT_PATH = '/checkout/receipt/'
@@ -195,7 +196,17 @@ PAYMENT_PROCESSOR_CONFIG = {
             'transaction_key': None,
             'redirect_url': None,
             'production_mode': False,
-        }
+        },
+        'myfatoorah': {
+            # Real tokens belong in the tenant's DJANGO_SETTINGS_OVERRIDE, never here.
+            'api_token': None,
+            # Sandbox is https://apitest.myfatoorah.com. Live is region-specific:
+            # api.myfatoorah.com (KW/BH/JO/OM), api-sa, api-ae, api-qa, api-eg.
+            'base_url': 'https://apitest.myfatoorah.com',
+            'webhook_secret': None,
+            'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
+            'error_path': PAYMENT_PROCESSOR_ERROR_PATH,
+        },
     },
 }
 

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -111,6 +111,14 @@ PAYMENT_PROCESSOR_CONFIG = {
             'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
             'merchant_auth_name': config_from_yaml.get('AUTHORIZENET_MERCHANT_AUTH_NAME'),
             'transaction_key': config_from_yaml.get('AUTHORIZENET_TRANSACTION_KEY'),
+        },
+        'myfatoorah': {
+            'api_token': config_from_yaml.get('MYFATOORAH_API_TOKEN'),
+            # Sandbox. Live is region-specific -- see _oscar.py.
+            'base_url': config_from_yaml.get('MYFATOORAH_BASE_URL', 'https://apitest.myfatoorah.com'),
+            'webhook_secret': config_from_yaml.get('MYFATOORAH_WEBHOOK_SECRET'),
+            'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
+            'error_path': PAYMENT_PROCESSOR_ERROR_PATH,
         }
     },
 }

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -123,6 +123,13 @@ PAYMENT_PROCESSOR_CONFIG = {
             'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
             'merchant_auth_name': "fake_merchant_auth_name",
             'transaction_key': "edx_fake_key",
+        },
+        'myfatoorah': {
+            'api_token': 'fake-myfatoorah-api-token',
+            'base_url': 'https://apitest.myfatoorah.com',
+            'webhook_secret': 'fake-myfatoorah-webhook-secret',
+            'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
+            'error_path': PAYMENT_PROCESSOR_ERROR_PATH,
         }
     },
     'other': {
@@ -176,6 +183,13 @@ PAYMENT_PROCESSOR_CONFIG = {
             'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
             'merchant_auth_name': "fake_merchant_auth_name",
             'transaction_key': "edx_fake_key",
+        },
+        'myfatoorah': {
+            'api_token': 'other-fake-myfatoorah-api-token',
+            'base_url': 'https://apitest.myfatoorah.com',
+            'webhook_secret': 'other-fake-myfatoorah-webhook-secret',
+            'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
+            'error_path': PAYMENT_PROCESSOR_ERROR_PATH,
         }
     }
 }

--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -31,7 +31,10 @@ define([
             },
 
             onSuccess: function(data) {
-                var method = (data.payment_processor === 'stripe') ? 'GET' : 'POST';
+                // These processors hand back a hosted page to visit, not a form target
+                // to submit to, so they must be reached with a GET.
+                var getRedirectProcessors = ['stripe', 'myfatoorah'];
+                var method = (getRedirectProcessors.indexOf(data.payment_processor) !== -1) ? 'GET' : 'POST';
                 var $form = $('<form>', {
                     class: 'hidden',
                     action: data.payment_page_url,

--- a/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -168,6 +168,9 @@
                             {% elif processor.NAME == 'authorizenet' %}
                                 {# Translators: Do NOT translate the name Authorizenet. #}
                                 {% trans "Checkout with AuthorizeNet" as tmsg %}{{ tmsg | force_escape }}
+                            {% elif processor.NAME == 'myfatoorah' %}
+                                {# Translators: Do NOT translate the name MyFatoorah. #}
+                                {% trans "Checkout with MyFatoorah" as tmsg %}{{ tmsg | force_escape }}
                             {% endif %}
                         </button>
                     {% endfor %}


### PR DESCRIPTION
## What

Adds MyFatoorah as a payment processor. MyFatoorah is a MENA gateway (KNET, mada, Visa/Mastercard, Benefit, Apple Pay) covering KW, SA, AE, QA, BH, JO, OM and EG, requested by **ORYX**.

Ticket: [EDLYPRODUCT-8446](https://app.plane.so/arbisoft/projects/532be893-e868-4bf7-8d1d-c6d0d7f599b8/issues/5036dda9-7dc4-47bd-996b-336fa5bed46f)

## PCI DSS scope — please review this part first

Edly must never see, transmit or store cardholder data. The learner is redirected to MyFatoorah's own hosted page for card entry and returns with only an opaque `paymentId`. This targets **SAQ A**, and deliberately avoids **SAQ A-EP** (which applies once our page embeds the payment form via iframe/JS) and **SAQ D**.

Four properties hold that line, and all four are load-bearing:

- Subclasses `BasePaymentProcessor`, **not** `BaseClientSidePaymentProcessor`. The latter adds `get_template_name()` → `payment/myfatoorah.html`, which is exactly where a card input would eventually appear. PayPal — the correct analogue here — has no template at all.
- No card fields in `forms.py`, no template under `templates/payment/`. That absence is the control.
- Never calls MyFatoorah's `DirectPayment` endpoint, which their docs gate on the caller already being PCI certified.
- `_scrub()` applies a field allow-list before anything reaches `PaymentProcessorResponse`: masked PAN and brand are kept; cardholder name and expiry are dropped. `record_processor_response` persists whatever it is handed, forever, so this is filtered rather than trusting the gateway not to widen its payload later.

Two of these are asserted structurally in tests, not just by intent — the processor has no `template_name` attribute and is not a `BaseClientSidePaymentProcessor` subclass.

## Flow

```
basket → /api/v2/checkout/ → SendPayment (NotificationOption: LNK)
                                   ↓ InvoiceURL
                    302 → MyFatoorah hosted page (their method picker + card form)
                                   ↓
         CallBackUrl?paymentId=… → GetPaymentStatus (server-to-server) → verify → order
```

The signed webhook is **not** redundant: if the learner pays and closes the tab before the redirect completes, the callback never fires and the payment would otherwise never become an enrolment. Both entry points share one `place_order_for_payment` helper so their trust checks cannot drift apart, and both are idempotent — the pair produces exactly one order.

## Trust model

Payment state comes only from a server-side `GetPaymentStatus` call. The redirect query string and the webhook body are untrusted lookup keys, never evidence of payment. On top of that:

- Amount **and** currency are read from the gateway and compared against the basket; a mismatch places no order. Without the currency check, 100 of a weaker currency would buy a 100 USD seat.
- `CustomerReference` is cross-checked against the basket's order number.
- A valid webhook signature proves the message came from MyFatoorah, not that the payment succeeded — the status lookup still decides. There is a test for exactly that.
- Signature verification **fails closed**: a missing `webhook_secret` is not read as "no verification required".

I deliberately did not follow Cowpay's callback here. `views/cowpay.py:165-216` reads `payment_status == 'PAID'` straight from an unauthenticated, unsigned request body and resolves the user from a body field, so an unauthenticated caller can mint a paid order for any user; it also falls back to "the user's last non-empty basket". Worth a separate ticket — flagged on EDLYPRODUCT-8446.

## Files

**New**
- `extensions/payment/processors/myfatoorah.py`
- `extensions/payment/views/myfatoorah.py`
- `extensions/payment/migrations/0034_create_myfatoorah_switch.py` — waffle switch, created **inactive** (opt-in per tenant)
- `extensions/payment/tests/{processors,views}/test_myfatoorah.py`

**Modified**
- `settings/{_oscar,test,devstack}.py` — registration + config. Note `test.py` needs the block in **both** the `edx` and `other` partners, or the inherited `test_configuration` KeyErrors.
- `extensions/payment/urls.py` — `MYFATOORAH_URLS`; the long import is also wrapped, which fixes a pre-existing isort failure on that line.
- `extensions/payment/tests/mixins.py` — new `MyFatoorahMixin` (append-only).
- `static/js/pages/basket_page.js` — MyFatoorah's `InvoiceURL` is a GET page; POSTing a form at it fails. Added to the GET-redirect list alongside stripe.
- `templates/oscar/basket/partials/hosted_checkout_basket.html` — label branch. Without it the button renders with **no text**, since the label comes from an `{% if %}` chain over `processor.NAME`.

Real credentials go in each tenant's `SiteConfiguration.DJANGO_SETTINGS_OVERRIDE.PAYMENT_PROCESSOR_CONFIG` (already allow-listed), not in committed settings. The settings blocks here are placeholders, present because `test_configuration` requires them.

## Verification

In the devstack ecommerce container (Py3.8 / Django 2.2):

- **46/46 new tests pass**, including the security regressions: unpaid → no order, failed transaction → no order, underpayment → no order, currency mismatch → no order, `CustomerReference` mismatch → no order, bad/absent/tampered signature → 400, callback + webhook for one payment → exactly one order, and `_scrub` dropping non-allow-listed fields.
- `pycodestyle`, `isort`, `pylint` clean.
- Migration applies; switch created with `active=False`.
- Routes resolve; `get_processor_class_by_name('myfatoorah')` resolves.
- No regressions in the suites covering the shared-file edits: `tests/test_helpers.py` + `core/tests/test_models.py`, 59/59.

The 32 other failures in `extensions/payment/` are pre-existing and confined to authorizenet/cybersource/stripe/sdn/paypal modules — none in files this PR touches.

## Two things not done, deliberately

1. **The webhook signature field order is unverified.** MyFatoorah documents a specific order per event type but does not publish it. We sign in payload order, which round-trips in our tests but proves nothing about a real delivery. Flagged in a comment in `verify_webhook_signature`, and it must be confirmed against a live webhook in staging before go-live. Their servers cannot reach localhost, so this is not testable in devstack.
2. **No end-to-end browser purchase.** Blocked on a MyFatoorah sandbox API token from ORYX, not on code.

**Refunds are out of scope** — `issue_credit` raises `NotImplementedError`, matching Cowpay. Refunds are handled in the MyFatoorah portal for now.

One deployment note for whoever provisions ORYX: `basket.currency` comes from stock records stamped at product-creation time, so the tenant's `OSCAR_DEFAULT_CURRENCY` must be set **before** seats are published — seats created earlier keep the old currency.